### PR TITLE
Add no colon support for sub-commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-config": "^1.0.6",
     "@adobe/aio-cli-plugin-jwt-auth": "^1.0.9",
-    "@adobe/oclif-base-index-command": "^1.0.1",
+    "@adobe/oclif-base-index-command": "^1.0.2",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.1.2",
@@ -54,8 +54,8 @@
   },
   "repository": "adobe/aio-cli-plugin-console",
   "scripts": {
-    "posttest": "eslint src",
-    "test": "npm run unit-tests",
+    "eslint": "eslint src test",
+    "test": "npm run eslint && npm run unit-tests",
     "unit-tests": "jest --ci -w=2",
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-config": "^1.0.6",
     "@adobe/aio-cli-plugin-jwt-auth": "^1.0.9",
+    "@adobe/oclif-base-index-command": "^1.0.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.1.2",

--- a/src/commands/console/index.js
+++ b/src/commands/console/index.js
@@ -10,20 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const {Command, flags} = require('@oclif/command')
-const ListIntegrationsCommand = require('./list-integrations')
+const BaseIndexCommand = require('@adobe/oclif-base-index-command')
 
-class ConsoleCommand extends Command {
-  async run() {
-    const {flags} = this.parse(ListIntegrationsCommand)
-    // when this is run, no params are needed
-    // which is the same as `console:ls` (get list of integrations)
-    return ListIntegrationsCommand.run([`--passphrase=${flags.passphrase}`])
-  }
-}
-
-ConsoleCommand.flags = {
-  passphrase: flags.string({char: 'p', description: 'the passphrase for the private-key'}),
+class ConsoleCommand extends BaseIndexCommand {
 }
 
 // this is set in package.json, see https://github.com/oclif/oclif/issues/120

--- a/test/commands/console/index.test.js
+++ b/test/commands/console/index.test.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 const ConsoleCommand = require('../../../src/commands/console')
-const ListIntegrationsCommand = require('../../../src/commands/console/list-integrations')
 const ConsoleExports = require('../../../src')
 const {stdout} = require('stdout-stderr')
 
@@ -19,14 +18,11 @@ beforeAll(() => stdout.start())
 afterAll(() => stdout.stop())
 
 test('call with no params', async () => {
-  let spy = jest.spyOn(ConsoleCommand, 'run')
-  let spyList = jest.spyOn(ListIntegrationsCommand, 'run').mockImplementation(() => Promise.resolve())
-  await ConsoleCommand.run([])
+  expect.assertions(2)
 
-  expect(spy).toHaveBeenCalledTimes(1)
-  expect(spyList).toHaveBeenCalledTimes(1)
-  expect(spy).toHaveBeenCalledWith([])
-  expect(spyList).toHaveBeenCalledWith(['--passphrase=undefined'])
+  let runResult = ConsoleCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toEqual(new Error('Missing 1 required arg:\nsub-command\nSee more help with --help'))
 })
 
 test('exports', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds subcommand (topic) support without using the colon separator.
Now you can do:
```
./bin/run console select-integration....
./bin/run console list-integration....
```
