### PR TITLE
Change list-integrations --passphrase shortcut from '-r' to '-p'

### DIFF
--- a/src/commands/console/list-integrations.js
+++ b/src/commands/console/list-integrations.js
@@ -86,7 +86,7 @@ class ListIntegrationsCommand extends Command {
 ListIntegrationsCommand.description = 'lists integrations for use with Adobe I/O Runtime serverless functions'
 
 ListIntegrationsCommand.flags = {
-  passphrase: flags.string({ char: 'r', description: 'the passphrase for the private-key' }),
+  passphrase: flags.string({ char: 'p', description: 'the passphrase for the private-key' }),
   name: flags.boolean({ char: 'n', description: 'sort results by name' })
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change list-integrations --passphrase shortcut from '-r' to '-p'

<!--- Describe your changes in detail -->

## Related Issue

Closes #43

## Motivation and Context

Re-align the shortcut with the '-p' shortcut back with `--passphrase` shortcut usage in other commands. We can do this since the shortcut flag for `--page` has been removed.

## How Has This Been Tested?

npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.