### PR TITLE
add support for --yaml and --json list-integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm install -g @adobe/aio-cli-plugin-console
 $ ./bin/run COMMAND
 running command...
 $ ./bin/run (-v|--version|version)
-@adobe/aio-cli-plugin-console/2.0.2 darwin-x64 node-v10.16.0
+@adobe/aio-cli-plugin-console/2.0.3 darwin-x64 node-v10.16.1
 $ ./bin/run --help [COMMAND]
 USAGE
   $ ./bin/run COMMAND
@@ -42,12 +42,12 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-* [`./bin/run console`](#binrun-console)
-* [`./bin/run console:integration NAMESPACE`](#binrun-consoleintegration-namespace)
-* [`./bin/run console:list-integrations`](#binrun-consolelist-integrations)
-* [`./bin/run console:reset-integration [INTEGRATION_ID]`](#binrun-consolereset-integration-integration_id)
-* [`./bin/run console:select-integration [INTEGRATION_ID]`](#binrun-consoleselect-integration-integration_id)
-* [`./bin/run console:selected-integration`](#binrun-consoleselected-integration)
+* [`./bin/run console`](#bin-run-console)
+* [`./bin/run console:integration NAMESPACE`](#bin-run-consoleintegration-namespace)
+* [`./bin/run console:list-integrations`](#bin-run-consolelist-integrations)
+* [`./bin/run console:reset-integration [INTEGRATION_ID]`](#bin-run-consolereset-integration-integration-id)
+* [`./bin/run console:select-integration [INTEGRATION_ID]`](#bin-run-consoleselect-integration-integration-id)
+* [`./bin/run console:selected-integration`](#bin-run-consoleselected-integration)
 
 ## `./bin/run console`
 
@@ -58,8 +58,10 @@ USAGE
   $ ./bin/run console
 
 OPTIONS
+  -j, --json                   output raw json
   -n, --name                   sort results by name
   -p, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output yaml
 
 ALIASES
   $ ./bin/run console:ls
@@ -80,7 +82,7 @@ EXAMPLES
   $ aio console current-integration
 ```
 
-_See code: [src/commands/console/index.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.2/src/commands/console/index.js)_
+_See code: [src/commands/console/index.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.3/src/commands/console/index.js)_
 
 ## `./bin/run console:integration NAMESPACE`
 
@@ -101,7 +103,7 @@ ALIASES
   $ ./bin/run console:int
 ```
 
-_See code: [src/commands/console/integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.2/src/commands/console/integration.js)_
+_See code: [src/commands/console/integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.3/src/commands/console/integration.js)_
 
 ## `./bin/run console:list-integrations`
 
@@ -112,15 +114,17 @@ USAGE
   $ ./bin/run console:list-integrations
 
 OPTIONS
+  -j, --json                   output raw json
   -n, --name                   sort results by name
   -p, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output yaml
 
 ALIASES
   $ ./bin/run console:ls
   $ ./bin/run console:list
 ```
 
-_See code: [src/commands/console/list-integrations.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.2/src/commands/console/list-integrations.js)_
+_See code: [src/commands/console/list-integrations.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.3/src/commands/console/list-integrations.js)_
 
 ## `./bin/run console:reset-integration [INTEGRATION_ID]`
 
@@ -138,7 +142,7 @@ ALIASES
   $ ./bin/run console:reset
 ```
 
-_See code: [src/commands/console/reset-integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.2/src/commands/console/reset-integration.js)_
+_See code: [src/commands/console/reset-integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.3/src/commands/console/reset-integration.js)_
 
 ## `./bin/run console:select-integration [INTEGRATION_ID]`
 
@@ -165,7 +169,7 @@ ALIASES
   $ ./bin/run console:select
 ```
 
-_See code: [src/commands/console/select-integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.2/src/commands/console/select-integration.js)_
+_See code: [src/commands/console/select-integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.3/src/commands/console/select-integration.js)_
 
 ## `./bin/run console:selected-integration`
 
@@ -183,5 +187,5 @@ ALIASES
   $ ./bin/run console:current
 ```
 
-_See code: [src/commands/console/selected-integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.2/src/commands/console/selected-integration.js)_
+_See code: [src/commands/console/selected-integration.js](https://github.com/adobe/aio-cli-plugin-console/blob/v2.0.3/src/commands/console/selected-integration.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-cli-plugin-console",
   "description": "Console integration plugin for the Adobe I/O CLI",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-console/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-console/issues",
   "dependencies": {
-    "@adobe/aio-cna-core-config": "^1.0.14",
     "@adobe/aio-cli-plugin-jwt-auth": "^2.0.1",
+    "@adobe/aio-cna-core-config": "^1.0.14",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.1.2",
     "cli-ux": "^5.1.0",
+    "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0"
   },
   "devDependencies": {

--- a/src/commands/console/list-integrations.js
+++ b/src/commands/console/list-integrations.js
@@ -82,12 +82,12 @@ class ListIntegrationsCommand extends Command {
       cli.table(result, {
         namespace: { },
         name: {
-          minWidth: 25,
+          minWidth: 25
         },
         apiKey: {
           header: 'API Key',
           minWidth: 15,
-          get: row => (row.apiKey) ? `${row.apiKey.substr(0,5)}...` : ''
+          get: row => (row.apiKey) ? `${row.apiKey.substr(0, 5)}...` : ''
         },
         status: {},
         current: {

--- a/src/commands/console/select-integration.js
+++ b/src/commands/console/select-integration.js
@@ -20,6 +20,9 @@ const debug = require('debug')('aio-cli-plugin-console:select-integration')
 const { confirm } = require('cli-ux').cli
 
 async function _selectIntegration (integrationId, passphrase, force, dest) {
+
+  debug('_selectIntegration integrationId', integrationId)
+
   if (!integrationId) {
     return Promise.reject(new Error('missing expected integration identifier.'))
   }
@@ -46,6 +49,8 @@ async function _selectIntegration (integrationId, passphrase, force, dest) {
       accept: 'application/json'
     }
   }
+
+  debug('calling with options:',options)
 
   debug(`fetch: ${tempUrl}`)
   const res = await fetch(tempUrl, options)

--- a/src/commands/console/select-integration.js
+++ b/src/commands/console/select-integration.js
@@ -21,7 +21,7 @@ const { confirm } = require('cli-ux').cli
 
 async function _selectIntegration (integrationId, passphrase, force, dest) {
   debug('_selectIntegration integrationId', integrationId)
-  
+
   if (!integrationId) {
     return Promise.reject(new Error('missing expected integration identifier.'))
   }

--- a/src/commands/console/select-integration.js
+++ b/src/commands/console/select-integration.js
@@ -20,8 +20,8 @@ const debug = require('debug')('aio-cli-plugin-console:select-integration')
 const { confirm } = require('cli-ux').cli
 
 async function _selectIntegration (integrationId, passphrase, force, dest) {
-
   debug('_selectIntegration integrationId', integrationId)
+  
   if (!integrationId) {
     return Promise.reject(new Error('missing expected integration identifier.'))
   }

--- a/src/commands/console/select-integration.js
+++ b/src/commands/console/select-integration.js
@@ -22,7 +22,6 @@ const { confirm } = require('cli-ux').cli
 async function _selectIntegration (integrationId, passphrase, force, dest) {
 
   debug('_selectIntegration integrationId', integrationId)
-
   if (!integrationId) {
     return Promise.reject(new Error('missing expected integration identifier.'))
   }
@@ -50,7 +49,7 @@ async function _selectIntegration (integrationId, passphrase, force, dest) {
     }
   }
 
-  debug('calling with options:',options)
+  debug('calling with options:', options)
 
   debug(`fetch: ${tempUrl}`)
   const res = await fetch(tempUrl, options)

--- a/test/commands/console/list-integrations.test.js
+++ b/test/commands/console/list-integrations.test.js
@@ -13,12 +13,13 @@ governing permissions and limitations under the License.
 const helpers = require('../../../src/console-helpers')
 helpers.getOrgs = jest.fn(() => Promise.resolve([{ id: 0 }]))
 helpers.getIntegrations = jest.fn()
-helpers.getIntegrations.mockImplementation(() => Promise.resolve({ page: 1,
+helpers.getIntegrations.mockImplementation(() => Promise.resolve({
+  page: 1,
   pages: 2,
   total: 3,
   content: [{ orgId: 0, id: 3, name: 'A', status: 'ENABLED' },
-    { orgId: 0, id: 2, name: 'B', status: 'ENABLED' },
-    { orgId: 0, id: 1, name: 'C', status: 'ENABLED', apiKey: '123456' }]
+  { orgId: 0, id: 2, name: 'B', status: 'ENABLED' },
+  { orgId: 0, id: 1, name: 'C', status: 'ENABLED', apiKey: '123456' }]
 }))
 
 const ListIntegrationsCommand = require('../../../src/commands/console/list-integrations')
@@ -57,12 +58,12 @@ test('list-integrations - mock success', async () => {
 
   let runResult = ListIntegrationsCommand.run([])
   return expect(runResult).resolves.toEqual([
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }])
 })
 
 test('list-integrations - mock success --yaml', async () => {
@@ -78,12 +79,12 @@ test('list-integrations - mock success --yaml', async () => {
 
   let runResult = ListIntegrationsCommand.run(['-y'])
   return expect(runResult).resolves.toEqual([
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }])
 })
 
 test('list-integrations - mock success --json', async () => {
@@ -99,12 +100,12 @@ test('list-integrations - mock success --json', async () => {
 
   let runResult = ListIntegrationsCommand.run(['-j'])
   return expect(runResult).resolves.toEqual([
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' }, 
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }])
 })
 
 test('list-integrations - mock success sort by name', async () => {
@@ -121,12 +122,12 @@ test('list-integrations - mock success sort by name', async () => {
 
   let runResult = ListIntegrationsCommand.run(['--name'])
   return expect(runResult).resolves.toEqual([
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' }, 
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' }])
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }])
 })
 
 test('list-integrations - mock success, multiple pages', async () => {
@@ -142,17 +143,17 @@ test('list-integrations - mock success, multiple pages', async () => {
 
   let runResult = ListIntegrationsCommand.run([])
   return expect(runResult).resolves.toEqual([
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
-    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
+    { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }])
 })
 
 test('ls missing client_id', async () => {
   config.get.mockImplementation(() => {
-    return { }
+    return {}
   })
 
   expect.assertions(2)

--- a/test/commands/console/list-integrations.test.js
+++ b/test/commands/console/list-integrations.test.js
@@ -18,8 +18,8 @@ helpers.getIntegrations.mockImplementation(() => Promise.resolve({
   pages: 2,
   total: 3,
   content: [{ orgId: 0, id: 3, name: 'A', status: 'ENABLED' },
-  { orgId: 0, id: 2, name: 'B', status: 'ENABLED' },
-  { orgId: 0, id: 1, name: 'C', status: 'ENABLED', apiKey: '123456' }]
+    { orgId: 0, id: 2, name: 'B', status: 'ENABLED' },
+    { orgId: 0, id: 1, name: 'C', status: 'ENABLED', apiKey: '123456' }]
 }))
 
 const ListIntegrationsCommand = require('../../../src/commands/console/list-integrations')
@@ -56,7 +56,7 @@ test('list-integrations - mock success', async () => {
 
   expect.assertions(1)
 
-  let runResult = ListIntegrationsCommand.run([])
+  const runResult = ListIntegrationsCommand.run([])
   return expect(runResult).resolves.toEqual([
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
@@ -77,7 +77,7 @@ test('list-integrations - mock success --yaml', async () => {
 
   expect.assertions(1)
 
-  let runResult = ListIntegrationsCommand.run(['-y'])
+  const runResult = ListIntegrationsCommand.run(['-y'])
   return expect(runResult).resolves.toEqual([
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
@@ -98,7 +98,7 @@ test('list-integrations - mock success --json', async () => {
 
   expect.assertions(1)
 
-  let runResult = ListIntegrationsCommand.run(['-j'])
+  const runResult = ListIntegrationsCommand.run(['-j'])
   return expect(runResult).resolves.toEqual([
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
@@ -120,7 +120,7 @@ test('list-integrations - mock success sort by name', async () => {
   jest.mock('node-fetch', () => jest.fn().mockImplementation(() => null))
   expect.assertions(1)
 
-  let runResult = ListIntegrationsCommand.run(['--name'])
+  const runResult = ListIntegrationsCommand.run(['--name'])
   return expect(runResult).resolves.toEqual([
     { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
     { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' },
@@ -141,7 +141,7 @@ test('list-integrations - mock success, multiple pages', async () => {
 
   expect.assertions(1)
 
-  let runResult = ListIntegrationsCommand.run([])
+  const runResult = ListIntegrationsCommand.run([])
   return expect(runResult).resolves.toEqual([
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },
     { apiKey: '123456', id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' },

--- a/test/commands/console/list-integrations.test.js
+++ b/test/commands/console/list-integrations.test.js
@@ -18,7 +18,7 @@ helpers.getIntegrations.mockImplementation(() => Promise.resolve({ page: 1,
   total: 3,
   content: [{ orgId: 0, id: 3, name: 'A', status: 'ENABLED' },
     { orgId: 0, id: 2, name: 'B', status: 'ENABLED' },
-    { orgId: 0, id: 1, name: 'C', status: 'ENABLED' }]
+    { orgId: 0, id: 1, name: 'C', status: 'ENABLED', apiKey: '123456' }]
 }))
 
 const ListIntegrationsCommand = require('../../../src/commands/console/list-integrations')
@@ -55,8 +55,56 @@ test('list-integrations - mock success', async () => {
 
   expect.assertions(1)
 
-  const runResult = ListIntegrationsCommand.run([])
-  return expect(runResult).resolves.toEqual([{ id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }, { id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }, { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' }, { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' }, { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }, { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }])
+  let runResult = ListIntegrationsCommand.run([])
+  return expect(runResult).resolves.toEqual([
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
+})
+
+test('list-integrations - mock success --yaml', async () => {
+  config.get.mockImplementation(() => {
+    return {
+      client_id: '1234',
+      console_get_orgs_url: '...',
+      namespace: '0_1'
+    }
+  })
+
+  expect.assertions(1)
+
+  let runResult = ListIntegrationsCommand.run(['-y'])
+  return expect(runResult).resolves.toEqual([
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
+})
+
+test('list-integrations - mock success --json', async () => {
+  config.get.mockImplementation(() => {
+    return {
+      client_id: '1234',
+      console_get_orgs_url: '...',
+      namespace: '0_1'
+    }
+  })
+
+  expect.assertions(1)
+
+  let runResult = ListIntegrationsCommand.run(['-j'])
+  return expect(runResult).resolves.toEqual([
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' }, 
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
 })
 
 test('list-integrations - mock success sort by name', async () => {
@@ -71,8 +119,14 @@ test('list-integrations - mock success sort by name', async () => {
   jest.mock('node-fetch', () => jest.fn().mockImplementation(() => null))
   expect.assertions(1)
 
-  const runResult = ListIntegrationsCommand.run(['--name'])
-  return expect(runResult).resolves.toEqual([{ id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }, { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }, { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' }, { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' }, { id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }, { id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }])
+  let runResult = ListIntegrationsCommand.run(['--name'])
+  return expect(runResult).resolves.toEqual([
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' }, 
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' }])
 })
 
 test('list-integrations - mock success, multiple pages', async () => {
@@ -86,8 +140,14 @@ test('list-integrations - mock success, multiple pages', async () => {
 
   expect.assertions(1)
 
-  const runResult = ListIntegrationsCommand.run([])
-  return expect(runResult).resolves.toEqual([{ id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }, { id: 1, name: 'C', namespace: '0_1', orgId: 0, selected: true, status: 'ENABLED' }, { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' }, { id: 2, name: 'B', namespace: '0_2', orgId: 0, selected: false, status: 'ENABLED' }, { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }, { id: 3, name: 'A', namespace: '0_3', orgId: 0, selected: false, status: 'ENABLED' }])
+  let runResult = ListIntegrationsCommand.run([])
+  return expect(runResult).resolves.toEqual([
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'apiKey': '123456', 'id': 1, 'name': 'C', 'namespace': '0_1', 'orgId': 0, 'selected': true, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 2, 'name': 'B', 'namespace': '0_2', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' },
+    { 'id': 3, 'name': 'A', 'namespace': '0_3', 'orgId': 0, 'selected': false, 'status': 'ENABLED' }])
 })
 
 test('ls missing client_id', async () => {


### PR DESCRIPTION

## Description

-y and --yaml for list-integrations to display YAML with ALL result data
-j and --json for list-integrations to display JSON with ALL result data



## Motivation and Context

there is a bunch of other information in the results that is not shown in the table

## How Has This Been Tested?

Updated tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
