### PR TITLE
fix: Response logging error due `.json()` can't be called more than once

### DIFF
--- a/src/commands/console/reset-integration.js
+++ b/src/commands/console/reset-integration.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { responseInterceptor, fetchWrapper, getNamespaceUrl, getApiKey, getIMSOrgId } = require('../../console-helpers')
+const { consumeResponseJson, fetchWrapper, getNamespaceUrl, getApiKey, getIMSOrgId } = require('../../console-helpers')
 const debug = require('debug')('aio-cli-plugin-console:reset-integration')
 
 async function _resetIntegration (integrationId, passphrase) {
@@ -43,10 +43,12 @@ async function _resetIntegration (integrationId, passphrase) {
     }
   }
 
-  return fetchWrapper(tempUrl, options).then((res) => {
-    responseInterceptor(res)
-    if (res.ok) return res.json()
-    else throw new Error(`Cannot retrieve integration: ${tempUrl} (${res.status} ${res.statusText})`)
+  return fetchWrapper(tempUrl, options).then(res => {
+    if (res.ok) {
+      return consumeResponseJson(res)
+    } else {
+      throw new Error(`Cannot retrieve integration: ${tempUrl} (${res.status} ${res.statusText})`)
+    }
   })
 }
 

--- a/src/console-helpers.js
+++ b/src/console-helpers.js
@@ -21,18 +21,23 @@ const fs = require('fs')
  *
  * @param {string} url the url to fetch from
  * @param {object} options the options for fetch
+* @return {object} the JSON response, if any
  */
-function responseInterceptor (response) {
+async function consumeResponseJson (response) {
   debug('RESPONSE', response)
+  let json = {}
+
   if (response.ok) {
-    const text = (response.text instanceof Function) ? response.text() : ''
+    const text = (response.text instanceof Function) ? (await response.text()) : ''
     try {
-      debug('DATA\n', JSON.stringify(JSON.parse(text), null, 2))
+      // try to parse
+      json = JSON.parse(text)
+      debug('DATA\n', JSON.stringify(json, null, 2))
     } catch (e) {
       debug('DATA\n', text)
     }
   }
-  return response
+  return json
 }
 
 /**
@@ -64,10 +69,12 @@ async function getOrgs (accessToken, apiKey) {
     }
   }
 
-  return fetchWrapper(orgsUrl, options).then((res) => {
-    responseInterceptor(res)
-    if (res.ok) return res.json()
-    else throw new Error(`Cannot retrieve organizations: ${orgsUrl} (${res.status} ${res.statusText})`)
+  return fetchWrapper(orgsUrl, options).then(res => {
+    if (res.ok) {
+      return consumeResponseJson(res)
+    } else {
+      throw new Error(`Cannot retrieve organizations: ${orgsUrl} (${res.status} ${res.statusText})`)
+    }
   })
 }
 
@@ -154,10 +161,12 @@ async function getIntegrations (orgId, accessToken, apiKey, { pageNum = 1, pageS
     }
   }
 
-  return fetchWrapper(integrationsUrl, options).then((res) => {
-    responseInterceptor(res)
-    if (res.ok) return res.json()
-    else throw new Error(`Cannot retrieve integrations: ${integrationsUrl} (${res.status} ${res.statusText})`)
+  return fetchWrapper(integrationsUrl, options).then(res => {
+    if (res.ok) {
+      return consumeResponseJson(res)
+    } else {
+      throw new Error(`Cannot retrieve integrations: ${integrationsUrl} (${res.status} ${res.statusText})`)
+    }
   })
 }
 
@@ -180,10 +189,12 @@ async function getIntegration (namespace, accessToken, apiKey) {
     }
   }
 
-  return fetchWrapper(integrationUrl, options).then((res) => {
-    responseInterceptor(res)
-    if (res.ok) return res.json()
-    else throw new Error(`Cannot retrieve integration: ${integrationUrl} (${res.status} ${res.statusText})`)
+  return fetchWrapper(integrationUrl, options).then(res => {
+    if (res.ok) {
+      return consumeResponseJson(res)
+    } else {
+      throw new Error(`Cannot retrieve integration: ${integrationUrl} (${res.status} ${res.statusText})`)
+    }
   })
 }
 
@@ -206,5 +217,5 @@ module.exports = {
   getIntegration,
   getConfig,
   fetchWrapper,
-  responseInterceptor
+  consumeResponseJson
 }

--- a/test/commands/console/integration.test.js
+++ b/test/commands/console/integration.test.js
@@ -14,14 +14,14 @@ const CurrentIntegrationCommand = require('../../../src/commands/console/integra
 jest.mock('node-fetch', () => jest.fn().mockImplementationOnce(() => {
   return Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ id: 0 })
+    text: () => Promise.resolve('{ "id": 0 }')
   })
 })
   .mockImplementationOnce(() => {
     return Promise.resolve({
       ok: true,
-      json: () => Promise.resolve(
-        { orgId: 0, id: 3, name: 'C' }
+      text: () => Promise.resolve(
+        '{ "orgId": 0, "id": 3, "name": "C" }'
       )
     })
   }))
@@ -37,7 +37,7 @@ jest.mock('@adobe/aio-cli-plugin-jwt-auth', () => {
   }
 })
 
-test('list-integrations - missing config', async () => {
+test('current-integration - missing config', async () => {
   expect.assertions(2)
 
   const runResult = CurrentIntegrationCommand.run(['org_int'])
@@ -45,7 +45,7 @@ test('list-integrations - missing config', async () => {
   await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
 })
 
-test('list-integrations - mock success', async () => {
+test('current-integration - mock success', async () => {
   config.get.mockImplementation(() => {
     return {
       client_id: '1234',

--- a/test/commands/console/reset-integration.test.js
+++ b/test/commands/console/reset-integration.test.js
@@ -60,7 +60,7 @@ test('reset-integration - console_get_namespaces_url, does not end with forward 
 
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   expect.assertions(2)
@@ -80,7 +80,7 @@ test('reset-integration - mock success', async () => {
 
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   expect.assertions(3)

--- a/test/commands/console/select-integration.test.js
+++ b/test/commands/console/select-integration.test.js
@@ -26,7 +26,7 @@ beforeEach(() => {
   cli.confirm.mockImplementation(() => true)
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({})
+    text: () => Promise.resolve('{}')
   })
 })
 
@@ -68,7 +68,7 @@ test('select-integration - console_get_namespaces_url, does not end with forward
 
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   expect.assertions(2)
@@ -89,7 +89,7 @@ test('select-integration - mock success', async () => {
   expect.assertions(4)
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   const runResult = SelectIntegrationCommand.run(['5_5'])
@@ -110,7 +110,7 @@ test('select-integration - write local', async () => {
   expect.assertions(4)
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   const runResult = SelectIntegrationCommand.run(['5_5', '--local'])
@@ -131,7 +131,7 @@ test('select-integration - write global', async () => {
   expect.assertions(4)
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   const runResult = SelectIntegrationCommand.run(['5_5', '--global'])
@@ -240,7 +240,7 @@ test('select-integration - mock success and overwrite .wskprops', async () => {
 
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   expect.assertions(2)
@@ -262,7 +262,7 @@ test('select-integration - mock success and dont overwrite .wskprops', async () 
 
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   expect.assertions(3)
@@ -284,7 +284,7 @@ test('select-integration - mock .wskprops does not exist', async () => {
 
   mockResult = Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ name: 'Basil', auth: '======' })
+    text: () => Promise.resolve(JSON.stringify({ name: 'Basil', auth: '======' }))
   })
 
   expect.assertions(2)

--- a/test/commands/console/selected-integration.test.js
+++ b/test/commands/console/selected-integration.test.js
@@ -18,14 +18,14 @@ const Command = require('../../../src/commands/console/selected-integration')
 jest.mock('node-fetch', () => jest.fn().mockImplementationOnce(() => {
   return Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ id: 0 })
+    text: () => Promise.resolve('{ "id": 0 }')
   })
 })
   .mockImplementationOnce(() => {
     return Promise.resolve({
       ok: true,
-      json: () => Promise.resolve(
-        { orgId: 0, id: 3, name: 'C' }
+      text: () => Promise.resolve(
+        '{ "orgId": 0, "id": 3, "name": "C" }'
       )
     })
   }))

--- a/test/console-helpers.js
+++ b/test/console-helpers.js
@@ -15,7 +15,7 @@ jest.mock('node-fetch', () => jest.fn().mockImplementation(() => mockResult))
 const fs = require('fs')
 const path = require('path')
 const config = require('@adobe/aio-cna-core-config')
-const { responseInterceptor, getApiKey, getIntegrations, getOrgs, getOrgsUrl, getIntegration, getWskProps, getConfig, getWskPropsFilePath, getNamespaceUrl, getIMSOrgId } = require('../src/console-helpers')
+const { consumeResponseJson, getApiKey, getIntegrations, getOrgs, getOrgsUrl, getIntegration, getWskProps, getConfig, getWskPropsFilePath, getNamespaceUrl, getIMSOrgId } = require('../src/console-helpers')
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -25,14 +25,18 @@ beforeEach(() => {
   })
 })
 
-test('responseInterceptor', () => {
-  let response = { ok: true, text: () => '{}' }
-  let newResponse = responseInterceptor(response)
-  expect(newResponse).toEqual(response)
+test('consumeResponseJson', async () => {
+  let response = { ok: true, text: () => '{ "foo": "bar" }' }
+  let json = await consumeResponseJson(response)
+  expect(json).toEqual({ foo: 'bar' })
 
   response = { ok: true }
-  newResponse = responseInterceptor(response)
-  expect(newResponse).toEqual(response)
+  json = await consumeResponseJson(response)
+  expect(json).toEqual({})
+
+  response = {}
+  json = await consumeResponseJson(response)
+  expect(json).toEqual({})
 })
 
 test('getWskPropsFilePath', () => {


### PR DESCRIPTION
This logs the response body text via debug().

<!--- Provide a general summary of your changes in the Title above -->

## Description

Looks like in the Fetch API, .json() or .text() will consume the body and can't be called more than once, per the spec (Fetch API future: the data should be streamed, so this is a design decision). 

The solution is to clone the Response, but that may cause problems because the buffer in `node-fetch` is 16KB versus 1MB for the browser.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests, and:
`aio console:ls`
`aio console:sel`
`aio console:reset`
`aio console:selected-integration`
`aio console:integration`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
