### PR TITLE
oclif readme --no-aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,36 +38,21 @@ $ aio console --help
 # Commands
 <!-- commands -->
 * [`aio console`](#aio-console)
-* [`aio console:org`](#aio-consoleorg)
-* [`aio console:org:list`](#aio-consoleorglist)
-* [`aio console:org:ls`](#aio-consoleorgls)
-* [`aio console:org:sel [ORGCODE]`](#aio-consoleorgsel-orgcode)
-* [`aio console:org:select [ORGCODE]`](#aio-consoleorgselect-orgcode)
-* [`aio console:project`](#aio-consoleproject)
-* [`aio console:project:list`](#aio-consoleprojectlist)
-* [`aio console:project:ls`](#aio-consoleprojectls)
-* [`aio console:project:sel [PROJECTIDORNAME]`](#aio-consoleprojectsel-projectidorname)
-* [`aio console:project:select [PROJECTIDORNAME]`](#aio-consoleprojectselect-projectidorname)
-* [`aio console:publickey`](#aio-consolepublickey)
-* [`aio console:publickey:delete IDORFINGERPRINT`](#aio-consolepublickeydelete-idorfingerprint)
-* [`aio console:publickey:list`](#aio-consolepublickeylist)
-* [`aio console:publickey:upload FILE`](#aio-consolepublickeyupload-file)
-* [`aio console:where`](#aio-consolewhere)
-* [`aio console:workspace`](#aio-consoleworkspace)
-* [`aio console:workspace:dl [DESTINATION]`](#aio-consoleworkspacedl-destination)
-* [`aio console:workspace:download [DESTINATION]`](#aio-consoleworkspacedownload-destination)
-* [`aio console:workspace:list`](#aio-consoleworkspacelist)
-* [`aio console:workspace:ls`](#aio-consoleworkspacels)
-* [`aio console:workspace:sel [WORKSPACEIDORNAME]`](#aio-consoleworkspacesel-workspaceidorname)
-* [`aio console:workspace:select [WORKSPACEIDORNAME]`](#aio-consoleworkspaceselect-workspaceidorname)
-* [`aio console:ws`](#aio-consolews)
-* [`aio console:ws:dl [DESTINATION]`](#aio-consolewsdl-destination)
-* [`aio console:ws:download [DESTINATION]`](#aio-consolewsdownload-destination)
-* [`aio console:ws:list`](#aio-consolewslist)
-* [`aio console:ws:ls`](#aio-consolewsls)
-* [`aio console:ws:sel [WORKSPACEIDORNAME]`](#aio-consolewssel-workspaceidorname)
-* [`aio console:ws:select [WORKSPACEIDORNAME]`](#aio-consolewsselect-workspaceidorname)
-* [`aio where`](#aio-where)
+* [`aio console org`](#aio-console-org)
+* [`aio console org list`](#aio-console-org-list)
+* [`aio console org select [ORGCODE]`](#aio-console-org-select-orgcode)
+* [`aio console project`](#aio-console-project)
+* [`aio console project list`](#aio-console-project-list)
+* [`aio console project select [PROJECTIDORNAME]`](#aio-console-project-select-projectidorname)
+* [`aio console publickey`](#aio-console-publickey)
+* [`aio console publickey delete IDORFINGERPRINT`](#aio-console-publickey-delete-idorfingerprint)
+* [`aio console publickey list`](#aio-console-publickey-list)
+* [`aio console publickey upload FILE`](#aio-console-publickey-upload-file)
+* [`aio console where`](#aio-console-where)
+* [`aio console workspace`](#aio-console-workspace)
+* [`aio console workspace download [DESTINATION]`](#aio-console-workspace-download-destination)
+* [`aio console workspace list`](#aio-console-workspace-list)
+* [`aio console workspace select [WORKSPACEIDORNAME]`](#aio-console-workspace-select-workspaceidorname)
 
 ## `aio console`
 
@@ -84,15 +69,15 @@ DESCRIPTION
   Console plugin for the Adobe I/O CLI
 ```
 
-_See code: [src/commands/console/index.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/index.ts)_
+_See code: [src/commands/console/index.js](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/index.js)_
 
-## `aio console:org`
+## `aio console org`
 
 Manage your Adobe I/O Console Organizations
 
 ```
 USAGE
-  $ aio console:org [--help]
+  $ aio console org [--help]
 
 FLAGS
   --help  Show help
@@ -101,15 +86,13 @@ DESCRIPTION
   Manage your Adobe I/O Console Organizations
 ```
 
-_See code: [src/commands/console/org/index.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/org/index.ts)_
-
-## `aio console:org:list`
+## `aio console org list`
 
 List your Organizations
 
 ```
 USAGE
-  $ aio console:org:list [--help] [-j | -y]
+  $ aio console org list [--help] [-j | -y]
 
 FLAGS
   -j, --json  Output json
@@ -120,38 +103,16 @@ DESCRIPTION
   List your Organizations
 
 ALIASES
-  $ aio console:org:ls
+  $ aio console org ls
 ```
 
-_See code: [src/commands/console/org/list.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/org/list.ts)_
-
-## `aio console:org:ls`
-
-List your Organizations
-
-```
-USAGE
-  $ aio console:org:ls [--help] [-j | -y]
-
-FLAGS
-  -j, --json  Output json
-  -y, --yml   Output yml
-  --help      Show help
-
-DESCRIPTION
-  List your Organizations
-
-ALIASES
-  $ aio console:org:ls
-```
-
-## `aio console:org:sel [ORGCODE]`
+## `aio console org select [ORGCODE]`
 
 Select an Organization
 
 ```
 USAGE
-  $ aio console:org:sel [ORGCODE] [--help]
+  $ aio console org select [ORGCODE] [--help]
 
 ARGUMENTS
   ORGCODE  Adobe Developer Console Org code
@@ -163,39 +124,16 @@ DESCRIPTION
   Select an Organization
 
 ALIASES
-  $ aio console:org:sel
+  $ aio console org sel
 ```
 
-## `aio console:org:select [ORGCODE]`
-
-Select an Organization
-
-```
-USAGE
-  $ aio console:org:select [ORGCODE] [--help]
-
-ARGUMENTS
-  ORGCODE  Adobe Developer Console Org code
-
-FLAGS
-  --help  Show help
-
-DESCRIPTION
-  Select an Organization
-
-ALIASES
-  $ aio console:org:sel
-```
-
-_See code: [src/commands/console/org/select.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/org/select.ts)_
-
-## `aio console:project`
+## `aio console project`
 
 Manage your Adobe I/O Console Projects
 
 ```
 USAGE
-  $ aio console:project [--help]
+  $ aio console project [--help]
 
 FLAGS
   --help  Show help
@@ -204,15 +142,13 @@ DESCRIPTION
   Manage your Adobe I/O Console Projects
 ```
 
-_See code: [src/commands/console/project/index.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/project/index.ts)_
-
-## `aio console:project:list`
+## `aio console project list`
 
 List your Projects for the selected Organization
 
 ```
 USAGE
-  $ aio console:project:list [--help] [--orgId <value>] [-j | -y]
+  $ aio console project list [--help] [--orgId <value>] [-j | -y]
 
 FLAGS
   -j, --json       Output json
@@ -224,39 +160,16 @@ DESCRIPTION
   List your Projects for the selected Organization
 
 ALIASES
-  $ aio console:project:ls
+  $ aio console project ls
 ```
 
-_See code: [src/commands/console/project/list.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/project/list.ts)_
-
-## `aio console:project:ls`
-
-List your Projects for the selected Organization
-
-```
-USAGE
-  $ aio console:project:ls [--help] [--orgId <value>] [-j | -y]
-
-FLAGS
-  -j, --json       Output json
-  -y, --yml        Output yml
-  --help           Show help
-  --orgId=<value>  OrgID for listing projects
-
-DESCRIPTION
-  List your Projects for the selected Organization
-
-ALIASES
-  $ aio console:project:ls
-```
-
-## `aio console:project:sel [PROJECTIDORNAME]`
+## `aio console project select [PROJECTIDORNAME]`
 
 Select a Project for the selected Organization
 
 ```
 USAGE
-  $ aio console:project:sel [PROJECTIDORNAME] [--help] [--orgId <value>]
+  $ aio console project select [PROJECTIDORNAME] [--help] [--orgId <value>]
 
 ARGUMENTS
   PROJECTIDORNAME  Adobe Developer Console Project id or Project name
@@ -269,40 +182,16 @@ DESCRIPTION
   Select a Project for the selected Organization
 
 ALIASES
-  $ aio console:project:sel
+  $ aio console project sel
 ```
 
-## `aio console:project:select [PROJECTIDORNAME]`
-
-Select a Project for the selected Organization
-
-```
-USAGE
-  $ aio console:project:select [PROJECTIDORNAME] [--help] [--orgId <value>]
-
-ARGUMENTS
-  PROJECTIDORNAME  Adobe Developer Console Project id or Project name
-
-FLAGS
-  --help           Show help
-  --orgId=<value>  Organization id of the Console Project to select
-
-DESCRIPTION
-  Select a Project for the selected Organization
-
-ALIASES
-  $ aio console:project:sel
-```
-
-_See code: [src/commands/console/project/select.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/project/select.ts)_
-
-## `aio console:publickey`
+## `aio console publickey`
 
 Manage Public Key Bindings for your Adobe I/O Console Workspaces
 
 ```
 USAGE
-  $ aio console:publickey [--help]
+  $ aio console publickey [--help]
 
 FLAGS
   --help  Show help
@@ -311,15 +200,13 @@ DESCRIPTION
   Manage Public Key Bindings for your Adobe I/O Console Workspaces
 ```
 
-_See code: [src/commands/console/publickey/index.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/publickey/index.ts)_
-
-## `aio console:publickey:delete IDORFINGERPRINT`
+## `aio console publickey delete IDORFINGERPRINT`
 
 Delete a public key certificate from the selected Workspace
 
 ```
 USAGE
-  $ aio console:publickey:delete [IDORFINGERPRINT] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId
+  $ aio console publickey delete [IDORFINGERPRINT] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId
   <value>]
 
 ARGUMENTS
@@ -335,15 +222,13 @@ DESCRIPTION
   Delete a public key certificate from the selected Workspace
 ```
 
-_See code: [src/commands/console/publickey/delete.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/publickey/delete.ts)_
-
-## `aio console:publickey:list`
+## `aio console publickey list`
 
 List the public key certificates bound to the selected Workspace
 
 ```
 USAGE
-  $ aio console:publickey:list [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>] [-j | -y]
+  $ aio console publickey list [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>] [-j | -y]
 
 FLAGS
   -j, --json             Output json
@@ -357,15 +242,13 @@ DESCRIPTION
   List the public key certificates bound to the selected Workspace
 ```
 
-_See code: [src/commands/console/publickey/list.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/publickey/list.ts)_
-
-## `aio console:publickey:upload FILE`
+## `aio console publickey upload FILE`
 
 Upload a public key certificate to the selected Workspace
 
 ```
 USAGE
-  $ aio console:publickey:upload [FILE] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>] [-j |
+  $ aio console publickey upload [FILE] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>] [-j |
   -y]
 
 ARGUMENTS
@@ -383,15 +266,13 @@ DESCRIPTION
   Upload a public key certificate to the selected Workspace
 ```
 
-_See code: [src/commands/console/publickey/upload.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/publickey/upload.ts)_
-
-## `aio console:where`
+## `aio console where`
 
 Show the currently selected Organization, Project and Workspace
 
 ```
 USAGE
-  $ aio console:where [--help] [-j | -y]
+  $ aio console where [--help] [-j | -y]
 
 FLAGS
   -j, --json  Output json
@@ -405,15 +286,13 @@ ALIASES
   $ aio where
 ```
 
-_See code: [src/commands/console/where/index.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/where/index.ts)_
-
-## `aio console:workspace`
+## `aio console workspace`
 
 Manage your Adobe I/O Console Workspaces
 
 ```
 USAGE
-  $ aio console:workspace [--help]
+  $ aio console workspace [--help]
 
 FLAGS
   --help  Show help
@@ -422,44 +301,16 @@ DESCRIPTION
   Manage your Adobe I/O Console Workspaces
 
 ALIASES
-  $ aio console:ws
+  $ aio console ws
 ```
 
-_See code: [src/commands/console/workspace/index.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/workspace/index.ts)_
-
-## `aio console:workspace:dl [DESTINATION]`
+## `aio console workspace download [DESTINATION]`
 
 Downloads the configuration for the selected Workspace
 
 ```
 USAGE
-  $ aio console:workspace:dl [DESTINATION] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>]
-
-ARGUMENTS
-  DESTINATION  Output file name or folder name where the Console Workspace configuration file should be saved
-
-FLAGS
-  --help                 Show help
-  --orgId=<value>        Organization id of the Console Workspace configuration to download
-  --projectId=<value>    Project id of the Console Workspace configuration to download
-  --workspaceId=<value>  Workspace id of the Console Workspace configuration to download
-
-DESCRIPTION
-  Downloads the configuration for the selected Workspace
-
-ALIASES
-  $ aio console:workspace:dl
-  $ aio console:ws:download
-  $ aio console:ws:dl
-```
-
-## `aio console:workspace:download [DESTINATION]`
-
-Downloads the configuration for the selected Workspace
-
-```
-USAGE
-  $ aio console:workspace:download [DESTINATION] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId
+  $ aio console workspace download [DESTINATION] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId
   <value>]
 
 ARGUMENTS
@@ -475,20 +326,18 @@ DESCRIPTION
   Downloads the configuration for the selected Workspace
 
 ALIASES
-  $ aio console:workspace:dl
-  $ aio console:ws:download
-  $ aio console:ws:dl
+  $ aio console workspace dl
+  $ aio console ws download
+  $ aio console ws dl
 ```
 
-_See code: [src/commands/console/workspace/download.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/workspace/download.ts)_
-
-## `aio console:workspace:list`
+## `aio console workspace list`
 
 List your Workspaces for your selected Project
 
 ```
 USAGE
-  $ aio console:workspace:list [--help] [-j | -y] [--orgId <value>] [--projectId <value>]
+  $ aio console workspace list [--help] [-j | -y] [--orgId <value>] [--projectId <value>]
 
 FLAGS
   -j, --json           Output json
@@ -501,44 +350,18 @@ DESCRIPTION
   List your Workspaces for your selected Project
 
 ALIASES
-  $ aio console:workspace:ls
-  $ aio console:ws:list
-  $ aio console:ws:ls
+  $ aio console workspace ls
+  $ aio console ws list
+  $ aio console ws ls
 ```
 
-_See code: [src/commands/console/workspace/list.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/workspace/list.ts)_
-
-## `aio console:workspace:ls`
-
-List your Workspaces for your selected Project
-
-```
-USAGE
-  $ aio console:workspace:ls [--help] [-j | -y] [--orgId <value>] [--projectId <value>]
-
-FLAGS
-  -j, --json           Output json
-  -y, --yml            Output yml
-  --help               Show help
-  --orgId=<value>      Organization id of the Console Workspaces to list
-  --projectId=<value>  Project id of the Console Workspaces to list
-
-DESCRIPTION
-  List your Workspaces for your selected Project
-
-ALIASES
-  $ aio console:workspace:ls
-  $ aio console:ws:list
-  $ aio console:ws:ls
-```
-
-## `aio console:workspace:sel [WORKSPACEIDORNAME]`
+## `aio console workspace select [WORKSPACEIDORNAME]`
 
 Select a Workspace for the selected Project
 
 ```
 USAGE
-  $ aio console:workspace:sel [WORKSPACEIDORNAME] [--help] [--orgId <value>] [--projectId <value>]
+  $ aio console workspace select [WORKSPACEIDORNAME] [--help] [--orgId <value>] [--projectId <value>]
 
 ARGUMENTS
   WORKSPACEIDORNAME  Adobe Developer Console Workspace id or Workspace name
@@ -552,223 +375,8 @@ DESCRIPTION
   Select a Workspace for the selected Project
 
 ALIASES
-  $ aio console:workspace:sel
-  $ aio console:ws:select
-  $ aio console:ws:sel
-```
-
-## `aio console:workspace:select [WORKSPACEIDORNAME]`
-
-Select a Workspace for the selected Project
-
-```
-USAGE
-  $ aio console:workspace:select [WORKSPACEIDORNAME] [--help] [--orgId <value>] [--projectId <value>]
-
-ARGUMENTS
-  WORKSPACEIDORNAME  Adobe Developer Console Workspace id or Workspace name
-
-FLAGS
-  --help               Show help
-  --orgId=<value>      Organization id of the Console Workspace to select
-  --projectId=<value>  Project id of the Console Workspace to select
-
-DESCRIPTION
-  Select a Workspace for the selected Project
-
-ALIASES
-  $ aio console:workspace:sel
-  $ aio console:ws:select
-  $ aio console:ws:sel
-```
-
-_See code: [src/commands/console/workspace/select.ts](https://github.com/adobe/aio-cli-plugin-console/blob/4.0.0/src/commands/console/workspace/select.ts)_
-
-## `aio console:ws`
-
-Manage your Adobe I/O Console Workspaces
-
-```
-USAGE
-  $ aio console:ws [--help]
-
-FLAGS
-  --help  Show help
-
-DESCRIPTION
-  Manage your Adobe I/O Console Workspaces
-
-ALIASES
-  $ aio console:ws
-```
-
-## `aio console:ws:dl [DESTINATION]`
-
-Downloads the configuration for the selected Workspace
-
-```
-USAGE
-  $ aio console:ws:dl [DESTINATION] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>]
-
-ARGUMENTS
-  DESTINATION  Output file name or folder name where the Console Workspace configuration file should be saved
-
-FLAGS
-  --help                 Show help
-  --orgId=<value>        Organization id of the Console Workspace configuration to download
-  --projectId=<value>    Project id of the Console Workspace configuration to download
-  --workspaceId=<value>  Workspace id of the Console Workspace configuration to download
-
-DESCRIPTION
-  Downloads the configuration for the selected Workspace
-
-ALIASES
-  $ aio console:workspace:dl
-  $ aio console:ws:download
-  $ aio console:ws:dl
-```
-
-## `aio console:ws:download [DESTINATION]`
-
-Downloads the configuration for the selected Workspace
-
-```
-USAGE
-  $ aio console:ws:download [DESTINATION] [--help] [--orgId <value>] [--projectId <value>] [--workspaceId <value>]
-
-ARGUMENTS
-  DESTINATION  Output file name or folder name where the Console Workspace configuration file should be saved
-
-FLAGS
-  --help                 Show help
-  --orgId=<value>        Organization id of the Console Workspace configuration to download
-  --projectId=<value>    Project id of the Console Workspace configuration to download
-  --workspaceId=<value>  Workspace id of the Console Workspace configuration to download
-
-DESCRIPTION
-  Downloads the configuration for the selected Workspace
-
-ALIASES
-  $ aio console:workspace:dl
-  $ aio console:ws:download
-  $ aio console:ws:dl
-```
-
-## `aio console:ws:list`
-
-List your Workspaces for your selected Project
-
-```
-USAGE
-  $ aio console:ws:list [--help] [-j | -y] [--orgId <value>] [--projectId <value>]
-
-FLAGS
-  -j, --json           Output json
-  -y, --yml            Output yml
-  --help               Show help
-  --orgId=<value>      Organization id of the Console Workspaces to list
-  --projectId=<value>  Project id of the Console Workspaces to list
-
-DESCRIPTION
-  List your Workspaces for your selected Project
-
-ALIASES
-  $ aio console:workspace:ls
-  $ aio console:ws:list
-  $ aio console:ws:ls
-```
-
-## `aio console:ws:ls`
-
-List your Workspaces for your selected Project
-
-```
-USAGE
-  $ aio console:ws:ls [--help] [-j | -y] [--orgId <value>] [--projectId <value>]
-
-FLAGS
-  -j, --json           Output json
-  -y, --yml            Output yml
-  --help               Show help
-  --orgId=<value>      Organization id of the Console Workspaces to list
-  --projectId=<value>  Project id of the Console Workspaces to list
-
-DESCRIPTION
-  List your Workspaces for your selected Project
-
-ALIASES
-  $ aio console:workspace:ls
-  $ aio console:ws:list
-  $ aio console:ws:ls
-```
-
-## `aio console:ws:sel [WORKSPACEIDORNAME]`
-
-Select a Workspace for the selected Project
-
-```
-USAGE
-  $ aio console:ws:sel [WORKSPACEIDORNAME] [--help] [--orgId <value>] [--projectId <value>]
-
-ARGUMENTS
-  WORKSPACEIDORNAME  Adobe Developer Console Workspace id or Workspace name
-
-FLAGS
-  --help               Show help
-  --orgId=<value>      Organization id of the Console Workspace to select
-  --projectId=<value>  Project id of the Console Workspace to select
-
-DESCRIPTION
-  Select a Workspace for the selected Project
-
-ALIASES
-  $ aio console:workspace:sel
-  $ aio console:ws:select
-  $ aio console:ws:sel
-```
-
-## `aio console:ws:select [WORKSPACEIDORNAME]`
-
-Select a Workspace for the selected Project
-
-```
-USAGE
-  $ aio console:ws:select [WORKSPACEIDORNAME] [--help] [--orgId <value>] [--projectId <value>]
-
-ARGUMENTS
-  WORKSPACEIDORNAME  Adobe Developer Console Workspace id or Workspace name
-
-FLAGS
-  --help               Show help
-  --orgId=<value>      Organization id of the Console Workspace to select
-  --projectId=<value>  Project id of the Console Workspace to select
-
-DESCRIPTION
-  Select a Workspace for the selected Project
-
-ALIASES
-  $ aio console:workspace:sel
-  $ aio console:ws:select
-  $ aio console:ws:sel
-```
-
-## `aio where`
-
-Show the currently selected Organization, Project and Workspace
-
-```
-USAGE
-  $ aio where [--help] [-j | -y]
-
-FLAGS
-  -j, --json  Output json
-  -y, --yml   Output yml
-  --help      Show help
-
-DESCRIPTION
-  Show the currently selected Organization, Project and Workspace
-
-ALIASES
-  $ aio where
+  $ aio console workspace sel
+  $ aio console ws select
+  $ aio console ws sel
 ```
 <!-- commandsstop -->

--- a/bin/run
+++ b/bin/run
@@ -12,5 +12,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+const oclif = require('@oclif/core')
+
+oclif.run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jest-haste-map": "^27.5.1",
     "jest-junit": "^13.0.0",
     "jest-plugin-fs": "^2.9.0",
-    "oclif": "^3.0.1",
+    "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.9",
     "typescript": "^4.5.4"
   },
@@ -70,7 +70,7 @@
     "eslint": "eslint src test e2e",
     "test": "npm run eslint && npm run unit-tests",
     "unit-tests": "jest --ci -w=2",
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest && oclif readme --no-aliases",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "e2e": "jest --config jest.config.e2e.js"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,8 @@
     "jest-junit": "^13.0.0",
     "jest-plugin-fs": "^2.9.0",
     "oclif": "^3.2.0",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^4.5.4"
+    "stdout-stderr": "^0.1.9"
   },
-  "engineStrict": true,
   "engines": {
     "node": "^14.18 || ^16.13 || >=18"
   },
@@ -55,6 +53,7 @@
   "oclif": {
     "commands": "./src/commands",
     "bin": "aio",
+    "topicSeparator": " ",
     "hooks": {
       "init": "./src/hooks/upgrade-config-hook.js"
     },


### PR DESCRIPTION
The new oclif README doc generator was listing the aliases as well as commands (which just clutters up the README docs), now there is a new flag --no-aliases. 