### PR TITLE
changed output to be project.title instead of name

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "repository": "adobe/aio-cli-plugin-console",
   "scripts": {
     "eslint": "eslint src test e2e",
-    "test": "npm run eslint && npm run unit-tests",
+    "test": "npm run unit-tests && npm run eslint",
     "unit-tests": "jest --ci -w=2",
     "prepack": "oclif manifest && oclif readme --no-aliases",
     "postpack": "rm -f oclif.manifest.json",

--- a/src/commands/console/index.js
+++ b/src/commands/console/index.js
@@ -63,26 +63,26 @@ class ConsoleCommand extends Command {
    * @param {string} [options.alternativeFormat] can be set to: 'json', 'yml'
    */
   printConsoleConfig (options = {}) {
-    const config = {}
-    config.org = this.getConfig('org.name')
-    config.project = this.getConfig('project.name')
-    config.workspace = this.getConfig('workspace.name')
+    const state = {}
+    state.org = this.getConfig('org.name')
+    state.project = this.getConfig('project.title')
+    state.workspace = this.getConfig('workspace.name')
 
     // handling json output
     if (options.alternativeFormat === 'json') {
-      this.printJson(config)
+      this.printJson(state)
       return
     }
 
     if (options.alternativeFormat === 'yml') {
-      this.printYaml(config)
+      this.printYaml(state)
       return
     }
 
     this.log('You are currently in:')
-    this.log(`1. Org: ${config.org || '<no org selected>'}`)
-    this.log(`2. Project: ${config.project || '<no project selected>'}`)
-    this.log(`3. Workspace: ${config.workspace || '<no workspace selected>'}`)
+    this.log(`1. Org: ${state.org || '<no org selected>'}`)
+    this.log(`2. Project: ${state.project || '<no project selected>'}`)
+    this.log(`3. Workspace: ${state.workspace || '<no workspace selected>'}`)
   }
 
   cleanOutput () {

--- a/src/commands/console/project/select.js
+++ b/src/commands/console/project/select.js
@@ -35,7 +35,7 @@ class SelectCommand extends ConsoleCommand {
       this.setConfig(CONFIG_KEYS.PROJECT, project)
       this.clearConfig(CONFIG_KEYS.WORKSPACE)
 
-      this.log(`Project selected ${project.name}`)
+      this.log(`Project selected : ${project.title}`)
 
       this.printConsoleConfig()
     } catch (err) {

--- a/src/commands/console/workspace/download.js
+++ b/src/commands/console/workspace/download.js
@@ -49,7 +49,7 @@ class DownloadCommand extends ConsoleCommand {
 
       let fileName = 'console.json'
       if (!flags.workspaceId && !flags.projectId && !flags.orgId) {
-        const projectName = this.getConfig(`${CONFIG_KEYS.PROJECT}.title`)
+        const projectName = this.getConfig(`${CONFIG_KEYS.PROJECT}.name`)
         const workspaceName = this.getConfig(`${CONFIG_KEYS.WORKSPACE}.name`)
         if (projectName && workspaceName) {
           // give a better default file name when possible

--- a/src/commands/console/workspace/download.js
+++ b/src/commands/console/workspace/download.js
@@ -49,7 +49,7 @@ class DownloadCommand extends ConsoleCommand {
 
       let fileName = 'console.json'
       if (!flags.workspaceId && !flags.projectId && !flags.orgId) {
-        const projectName = this.getConfig(`${CONFIG_KEYS.PROJECT}.name`)
+        const projectName = this.getConfig(`${CONFIG_KEYS.PROJECT}.title`)
         const workspaceName = this.getConfig(`${CONFIG_KEYS.WORKSPACE}.name`)
         if (projectName && workspaceName) {
           // give a better default file name when possible

--- a/test/commands/console/index.test.js
+++ b/test/commands/console/index.test.js
@@ -119,7 +119,7 @@ describe('ConsoleCommand', () => {
           if (key === `${CONFIG_KEYS.CONSOLE}.org.name`) {
             return 'THE_ORG'
           }
-          if (key === `${CONFIG_KEYS.CONSOLE}.project.name`) {
+          if (key === `${CONFIG_KEYS.CONSOLE}.project.title`) {
             return 'THE_PROJECT'
           }
           return null
@@ -136,7 +136,7 @@ describe('ConsoleCommand', () => {
           if (key === `${CONFIG_KEYS.CONSOLE}.org.name`) {
             return 'THE_ORG'
           }
-          if (key === `${CONFIG_KEYS.CONSOLE}.project.name`) {
+          if (key === `${CONFIG_KEYS.CONSOLE}.project.title`) {
             return 'THE_PROJECT'
           }
           if (key === `${CONFIG_KEYS.CONSOLE}.workspace.name`) {
@@ -156,7 +156,7 @@ describe('ConsoleCommand', () => {
           if (key === `${CONFIG_KEYS.CONSOLE}.org.name`) {
             return 'THE_ORG'
           }
-          if (key === `${CONFIG_KEYS.CONSOLE}.project.name`) {
+          if (key === `${CONFIG_KEYS.CONSOLE}.project.title`) {
             return 'THE_PROJECT'
           }
           if (key === `${CONFIG_KEYS.CONSOLE}.workspace.name`) {
@@ -181,7 +181,7 @@ describe('ConsoleCommand', () => {
           if (key === `${CONFIG_KEYS.CONSOLE}.org.name`) {
             return 'THE_ORG'
           }
-          if (key === `${CONFIG_KEYS.CONSOLE}.project.name`) {
+          if (key === `${CONFIG_KEYS.CONSOLE}.project.title`) {
             return 'THE_PROJECT'
           }
           if (key === `${CONFIG_KEYS.CONSOLE}.workspace.name`) {

--- a/test/commands/console/publickey/delete.test.js
+++ b/test/commands/console/publickey/delete.test.js
@@ -202,7 +202,7 @@ describe('console:publickey:delete', () => {
       if (key === 'console.project.id') {
         return '123'
       }
-      if (key === 'console.project.name') {
+      if (key === 'console.project.title') {
         return 'THE_PROJECT'
       }
       return null

--- a/test/commands/console/publickey/list.test.js
+++ b/test/commands/console/publickey/list.test.js
@@ -176,7 +176,7 @@ describe('console:publickey:list', () => {
       if (key === 'console.project.id') {
         return '123'
       }
-      if (key === 'console.project.name') {
+      if (key === 'console.project.title') {
         return 'THE_PROJECT'
       }
       return null

--- a/test/commands/console/publickey/upload.test.js
+++ b/test/commands/console/publickey/upload.test.js
@@ -219,7 +219,7 @@ describe('console:publickey:upload', () => {
       if (key === 'console.project.id') {
         return '123'
       }
-      if (key === 'console.project.name') {
+      if (key === 'console.project.title') {
         return 'THE_PROJECT'
       }
       return null

--- a/test/commands/console/workspace/download.test.js
+++ b/test/commands/console/workspace/download.test.js
@@ -58,7 +58,7 @@ function setDefaultMockConfigGet () {
     if (key === 'console.workspace.id') {
       return configWorkspaceId
     }
-    if (key === 'console.project.name') {
+    if (key === 'console.project.title') {
       return configProjectName
     }
     if (key === 'console.workspace.name') {
@@ -187,7 +187,7 @@ test('should download the config for the selected workspace, config workspaceNam
     if (key === 'console.workspace.id') {
       return configWorkspaceId
     }
-    if (key === 'console.project.name') {
+    if (key === 'console.project.title') {
       return configProjectName
     }
   })
@@ -225,7 +225,7 @@ test('should fail if the workspace config is missing', async () => {
     if (key === 'console.project.id') {
       return configProjectId
     }
-    if (key === 'console.project.name') {
+    if (key === 'console.project.title') {
       return configProjectName
     }
     if (key === 'console.org.name') {

--- a/test/commands/console/workspace/download.test.js
+++ b/test/commands/console/workspace/download.test.js
@@ -55,11 +55,11 @@ function setDefaultMockConfigGet () {
     if (key === 'console.project.id') {
       return configProjectId
     }
+    if (key === 'console.project.name') {
+      return configProjectName
+    }
     if (key === 'console.workspace.id') {
       return configWorkspaceId
-    }
-    if (key === 'console.project.title') {
-      return configProjectName
     }
     if (key === 'console.workspace.name') {
       return configWorkspaceName


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We were inconsistent with our project select/display output
The user was presented with a list of project.titles, but after they selected one, they were shown to have selected project.name which in many cases can look like an error.

## Related Issue

[#429](https://github.com/adobe/aio-cli/issues/429)
ACNA-2255


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
