### PR TITLE
ci: add PR review workflow for GitHub review bot

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,62 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    # NOTE: comment body matching is exact — /review or /pr-reviewer with no trailing spaces, newlines, or mixed case
+    # This does not fail the workflow; non-matching comments simply do not trigger the job
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       (github.event.comment.body == '/review' || github.event.comment.body == '/pr-reviewer'))
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.gate.outputs.allowed }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+    steps:
+      - name: Gate check
+        id: gate
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          else
+            # Fall back to "none" if user is not a collaborator (gh api returns 404) so allowed=false is output cleanly
+            PERM=$(gh api repos/$GITHUB_REPOSITORY/collaborators/$COMMENT_USER_LOGIN/permission --jq '.permission' 2>/dev/null || echo "none")
+            # Intentionally require admin or maintain; write collaborators are excluded to
+            # limit who can trigger potentially expensive/sensitive review automation.
+            if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
+              DATA=$(gh api repos/$GITHUB_REPOSITORY/pulls/$ISSUE_NUMBER)
+              echo "allowed=true" >> $GITHUB_OUTPUT
+              echo "pr_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+              echo "head_sha=$(echo "$DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+            else
+              echo "allowed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # GITHUB_REPOSITORY is set automatically by GitHub Actions (owner/repo)
+
+  review:
+    needs: check
+    if: needs.check.outputs.allowed == 'true'
+    uses: adobe/aio-reusable-workflows/.github/workflows/pr-review.yml@main
+    with:
+      pr_number: ${{ needs.check.outputs.pr_number }}
+      head_sha: ${{ needs.check.outputs.head_sha }}
+    secrets:
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.APP_BUILDER_AWS_BEARER_TOKEN_BEDROCK }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -35,9 +35,11 @@ jobs:
             # limit who can trigger potentially expensive/sensitive review automation.
             if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
               DATA=$(gh api repos/$GITHUB_REPOSITORY/pulls/$ISSUE_NUMBER) || { echo "allowed=false" >> $GITHUB_OUTPUT; exit 0; }
+              HEAD_SHA_VALUE=$(echo "$DATA" | jq -r '.head.sha')
+              if [ -z "$HEAD_SHA_VALUE" ] || [ "$HEAD_SHA_VALUE" = "null" ]; then echo "allowed=false" >> $GITHUB_OUTPUT; exit 0; fi
               echo "allowed=true" >> $GITHUB_OUTPUT
               echo "pr_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
-              echo "head_sha=$(echo "$DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+              echo "head_sha=$HEAD_SHA_VALUE" >> $GITHUB_OUTPUT
             else
               echo "allowed=false" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -34,7 +34,7 @@ jobs:
             # Intentionally require admin or maintain; write collaborators are excluded to
             # limit who can trigger potentially expensive/sensitive review automation.
             if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
-              DATA=$(gh api repos/$GITHUB_REPOSITORY/pulls/$ISSUE_NUMBER)
+              DATA=$(gh api repos/$GITHUB_REPOSITORY/pulls/$ISSUE_NUMBER) || { echo "allowed=false" >> $GITHUB_OUTPUT; exit 0; }
               echo "allowed=true" >> $GITHUB_OUTPUT
               echo "pr_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
               echo "head_sha=$(echo "$DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-review.yml` so the GitHub review bot can be enabled for this repo.
- Mirrors the workflow added in adobe/aio-cli-plugin-app-dev#163.
- Split out from #254 per [this review comment](https://github.com/adobe/aio-cli-plugin-console/pull/254#issuecomment-4270080317), since the workflow change is unrelated to the feature work in that PR.

Note: the one-time per-repo manual setup is still required to enable the bot, and the `APP_BUILDER_AWS_BEARER_TOKEN_BEDROCK` secret is already added to this repo.

## Test plan

- [ ] Verify workflow syntax is accepted by GitHub Actions once merged.
- [ ] Confirm the review bot is triggered on PR events and on `/review` or `/pr-reviewer` comments from authorized users.