### PR TITLE
fix: ACNA-4617 / #258 make api add additive, dedupe duplicate service records, surface JIL errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,8 @@ FLAGS
   -y, --yml                        Output yml
       --help                       Show help
       --license-config=<value>...  Product profile(s) for a service, format:
-                                   '<sdkCode>=<profileNameOrId>[,<profileNameOrId>...]'. Repeat for multiple services.
+                                   '<sdkCode>=<profileNameOrIdOrProductId>[,<profileNameOrIdOrProductId>...]'. Repeat for
+                                   multiple services.
       --orgId=<value>              Organization id
       --projectName=<value>        (required) Name of the project containing the workspace
       --service-code=<value>       (required) Comma-separated list of API service codes to add (e.g.
@@ -941,7 +942,8 @@ FLAGS
   -y, --yml                        Output yml
       --help                       Show help
       --license-config=<value>...  Product profile(s) for a service, format:
-                                   '<sdkCode>=<profileNameOrId>[,<profileNameOrId>...]'. Repeat for multiple services.
+                                   '<sdkCode>=<profileNameOrIdOrProductId>[,<profileNameOrIdOrProductId>...]'. Repeat for
+                                   multiple services.
       --orgId=<value>              Organization id
       --projectName=<value>        (required) Name of the project containing the workspace
       --service-code=<value>       (required) Comma-separated list of API service codes to add (e.g.

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -178,7 +178,7 @@ function assertSubscribeSuccess (response) {
   const formatted = errorDetails.length > 0
     ? errorDetails.map(d => {
       const where = d && d.sdkCode ? `${d.sdkCode}: ` : ''
-      const message = (d && d.message) || JSON.stringify(d)
+      const message = d == null ? '(unknown error)' : (d.message || JSON.stringify(d))
       return `  ${where}${message}`
     }).join('\n')
     : `  ${errorCodes.join(', ')}`

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -281,23 +281,17 @@ class AddCommand extends ConsoleCommand {
       // JIL's PUT-services endpoint replaces the credential's service list,
       // so fetch what's already subscribed and submit the union — otherwise
       // a later `api add` call silently wipes services attached by an earlier
-      // one. Treat any failure as "no existing services" so a brand-new
-      // workspace (no credential yet) still works.
-      let existingProperties = []
-      try {
-        existingProperties = await this.consoleCLI.getServicePropertiesFromWorkspaceWithCredentialType({
-          orgId,
-          projectId: project.id,
-          workspace,
-          supportedServices,
-          credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
-        })
-      } catch (err) {
-        // Lib returns [] (not throws) for a missing credential, so a thrown
-        // error here is something real (auth, network, server) and worth
-        // surfacing — proceeding with an empty list could overwrite state.
-        aioConsoleLogger.warn(`Could not fetch existing services for workspace ${workspace.name} (proceeding with empty list): ${err.message}`)
-      }
+      // one. The lib returns [] (not throws) for a workspace without a
+      // credential yet, so any thrown error here is real (auth, network,
+      // server) and we let it propagate: proceeding with an empty list
+      // would cause the very overwrite this merge is supposed to prevent.
+      const existingProperties = await this.consoleCLI.getServicePropertiesFromWorkspaceWithCredentialType({
+        orgId,
+        projectId: project.id,
+        workspace,
+        supportedServices,
+        credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
+      })
       const mergedProperties = mergeServiceProperties(existingProperties, serviceProperties)
       aioConsoleLogger.debug(`Submitting service list: ${JSON.stringify(mergedProperties.map(sp => sp.sdkCode))}`)
 

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -218,6 +218,18 @@ class AddCommand extends ConsoleCommand {
 
       const licenseConfigMap = parseLicenseConfigFlags(flags['license-config'] || [])
 
+      // Fail fast if --license-config references a service code that isn't in
+      // --service-code. Otherwise the entry is silently ignored, which is the
+      // exact silent-drop class of bug this command was patched against.
+      const requestedSet = new Set(requestedCodes)
+      const orphanLicenseConfigs = Object.keys(licenseConfigMap).filter(c => !requestedSet.has(c))
+      if (orphanLicenseConfigs.length > 0) {
+        this.error(
+          `--license-config given for service code(s) not in --service-code: ${orphanLicenseConfigs.join(', ')}. ` +
+          `Requested service codes: ${requestedCodes.join(', ')}.`
+        )
+      }
+
       const enabledServices = await this.consoleCLI.getEnabledServicesForOrg(orgId)
       const supportedServices = dedupeServicesByCode(enabledServices)
       aioConsoleLogger.debug(`Enabled services (deduped): ${JSON.stringify(supportedServices.map(s => s.code))}`)

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -113,6 +113,45 @@ function pickServiceForCode (services, code) {
 }
 
 /**
+ * Reduce the enabled-services list to one record per sdkCode using
+ * pickServiceForCode. Preserves the original ordering of the chosen records.
+ *
+ * @param {Array<object>} services enabled services
+ * @returns {Array<object>} deduplicated services
+ */
+function dedupeServicesByCode (services) {
+  const seen = new Set()
+  const result = []
+  for (const s of services) {
+    if (seen.has(s.code)) continue
+    seen.add(s.code)
+    const picked = pickServiceForCode(services, s.code)
+    if (picked) result.push(picked)
+  }
+  return result
+}
+
+/**
+ * Merge new service-subscription requests with existing services on the
+ * credential. JIL's PUT-services endpoint replaces the credential's
+ * service list rather than appending to it, so without this merge a
+ * subsequent `aio console workspace api add` call would silently wipe
+ * the services subscribed by an earlier call.
+ *
+ * For codes present in both, the new entry wins (the user is overriding
+ * the existing subscription, including any licenseConfig changes).
+ *
+ * @param {Array<object>} existing serviceProperties currently on the credential
+ * @param {Array<object>} requested serviceProperties the user is adding
+ * @returns {Array<object>} merged serviceProperties
+ */
+function mergeServiceProperties (existing, requested) {
+  const requestedCodes = new Set(requested.map(sp => sp.sdkCode))
+  const kept = existing.filter(sp => !requestedCodes.has(sp.sdkCode))
+  return [...kept, ...requested]
+}
+
+/**
  * Detect JIL subscription errors embedded in a 200 response and throw
  * a CLI-friendly error if any are found.
  *
@@ -175,13 +214,14 @@ class AddCommand extends ConsoleCommand {
       const licenseConfigMap = parseLicenseConfigFlags(flags['license-config'] || [])
 
       const enabledServices = await this.consoleCLI.getEnabledServicesForOrg(orgId)
-      aioConsoleLogger.debug(`Enabled services: ${JSON.stringify(enabledServices.map(s => s.code))}`)
+      const supportedServices = dedupeServicesByCode(enabledServices)
+      aioConsoleLogger.debug(`Enabled services (deduped): ${JSON.stringify(supportedServices.map(s => s.code))}`)
 
       const serviceProperties = []
       const notFound = []
       const missingProfiles = []
       for (const code of requestedCodes) {
-        const service = pickServiceForCode(enabledServices, code)
+        const service = supportedServices.find(s => s.code === code)
         if (!service) {
           notFound.push(code)
           continue
@@ -221,11 +261,31 @@ class AddCommand extends ConsoleCommand {
         )
       }
 
+      // JIL's PUT-services endpoint replaces the credential's service list,
+      // so fetch what's already subscribed and submit the union — otherwise
+      // a later `api add` call silently wipes services attached by an earlier
+      // one. Treat any failure as "no existing services" so a brand-new
+      // workspace (no credential yet) still works.
+      let existingProperties = []
+      try {
+        existingProperties = await this.consoleCLI.getServicePropertiesFromWorkspaceWithCredentialType({
+          orgId,
+          projectId: project.id,
+          workspace,
+          supportedServices,
+          credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
+        }) || []
+      } catch (err) {
+        aioConsoleLogger.debug(`Could not fetch existing services for workspace ${workspace.name}: ${err.message}`)
+      }
+      const mergedProperties = mergeServiceProperties(existingProperties, serviceProperties)
+      aioConsoleLogger.debug(`Submitting service list: ${JSON.stringify(mergedProperties.map(sp => sp.sdkCode))}`)
+
       const result = await this.consoleCLI.subscribeToServicesWithCredentialType({
         orgId,
         project,
         workspace,
-        serviceProperties,
+        serviceProperties: mergedProperties,
         credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
       })
 
@@ -293,3 +353,5 @@ module.exports.parseLicenseConfigFlags = parseLicenseConfigFlags
 module.exports.resolveLicenseConfigs = resolveLicenseConfigs
 module.exports.assertSubscribeSuccess = assertSubscribeSuccess
 module.exports.pickServiceForCode = pickServiceForCode
+module.exports.dedupeServicesByCode = dedupeServicesByCode
+module.exports.mergeServiceProperties = mergeServiceProperties

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -293,7 +293,10 @@ class AddCommand extends ConsoleCommand {
           credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
         })
       } catch (err) {
-        aioConsoleLogger.debug(`Could not fetch existing services for workspace ${workspace.name}: ${err.message}`)
+        // Lib returns [] (not throws) for a missing credential, so a thrown
+        // error here is something real (auth, network, server) and worth
+        // surfacing — proceeding with an empty list could overwrite state.
+        aioConsoleLogger.warn(`Could not fetch existing services for workspace ${workspace.name} (proceeding with empty list): ${err.message}`)
       }
       const mergedProperties = mergeServiceProperties(existingProperties, serviceProperties)
       aioConsoleLogger.debug(`Submitting service list: ${JSON.stringify(mergedProperties.map(sp => sp.sdkCode))}`)

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -126,8 +126,9 @@ function dedupeServicesByCode (services) {
   for (const s of services) {
     if (seen.has(s.code)) continue
     seen.add(s.code)
-    const picked = pickServiceForCode(services, s.code)
-    if (picked) result.push(picked)
+    // pickServiceForCode is guaranteed to return a record because s itself
+    // is in services and matches by code.
+    result.push(pickServiceForCode(services, s.code))
   }
   return result
 }
@@ -275,7 +276,7 @@ class AddCommand extends ConsoleCommand {
           workspace,
           supportedServices,
           credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
-        }) || []
+        })
       } catch (err) {
         aioConsoleLogger.debug(`Could not fetch existing services for workspace ${workspace.name}: ${err.message}`)
       }

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -80,6 +80,39 @@ function resolveLicenseConfigs (available, requested, sdkCode) {
 }
 
 /**
+ * Pick the best service record to subscribe when multiple records share
+ * the same sdkCode.
+ *
+ * Some services (notably Frame.io) appear twice in `getEnabledServicesForOrg`:
+ * once as `type: 'adobeid'` with no licenseConfigs (browser/SPA flow) and
+ * once as `type: 'entp'` with the product profile metadata required for
+ * OAuth Server-to-Server. `Array.find` returns whichever the API lists
+ * first, which silently drops `--license-config` when the adobeid record
+ * wins and causes JIL to reject the subscription. Since this command
+ * always uses OAuth Server-to-Server credentials, prefer the `entp` record
+ * (and, within that, the one that actually carries licenseConfigs).
+ *
+ * @param {Array<object>} services full enabled-services list
+ * @param {string} code sdkCode to look up
+ * @returns {object|undefined} the chosen service record, or undefined
+ */
+function pickServiceForCode (services, code) {
+  const matches = services.filter(s => s.code === code)
+  if (matches.length === 0) {
+    return undefined
+  }
+  const entpWithProfiles = matches.find(s => s.type === 'entp' && s.properties && Array.isArray(s.properties.licenseConfigs) && s.properties.licenseConfigs.length > 0)
+  if (entpWithProfiles) {
+    return entpWithProfiles
+  }
+  const entp = matches.find(s => s.type === 'entp')
+  if (entp) {
+    return entp
+  }
+  return matches[0]
+}
+
+/**
  * Detect JIL subscription errors embedded in a 200 response and throw
  * a CLI-friendly error if any are found.
  *
@@ -148,7 +181,7 @@ class AddCommand extends ConsoleCommand {
       const notFound = []
       const missingProfiles = []
       for (const code of requestedCodes) {
-        const service = enabledServices.find(s => s.code === code)
+        const service = pickServiceForCode(enabledServices, code)
         if (!service) {
           notFound.push(code)
           continue
@@ -259,3 +292,4 @@ module.exports = AddCommand
 module.exports.parseLicenseConfigFlags = parseLicenseConfigFlags
 module.exports.resolveLicenseConfigs = resolveLicenseConfigs
 module.exports.assertSubscribeSuccess = assertSubscribeSuccess
+module.exports.pickServiceForCode = pickServiceForCode

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -46,10 +46,15 @@ function parseLicenseConfigFlags (values) {
 
 /**
  * Match requested profile identifiers against a service's available
- * licenseConfigs by either id or name.
+ * licenseConfigs by id, name, or productId.
+ *
+ * Matching by productId lets users pass the value they see in
+ * `properties.licenseConfigs[].productId` from `aio console api list`,
+ * which is convenient for services like Frame.io that expose a single
+ * profile per product.
  *
  * @param {Array<{id: string, name: string, productId: string}>} available
- * @param {string[]} requested profile names or ids
+ * @param {string[]} requested profile names, ids, or productIds
  * @param {string} sdkCode service code for error messages
  * @returns {Array} selected licenseConfig objects
  */
@@ -57,7 +62,7 @@ function resolveLicenseConfigs (available, requested, sdkCode) {
   const selected = []
   const notFound = []
   for (const id of requested) {
-    const match = available.find(lc => lc.id === id || lc.name === id)
+    const match = available.find(lc => lc.id === id || lc.name === id || lc.productId === id)
     if (match) {
       selected.push(match)
     } else {
@@ -72,6 +77,35 @@ function resolveLicenseConfigs (available, requested, sdkCode) {
     )
   }
   return selected
+}
+
+/**
+ * Detect JIL subscription errors embedded in a 200 response and throw
+ * a CLI-friendly error if any are found.
+ *
+ * JIL returns `{ error: [<sdkCode>...], errorDetails: [{ sdkCode, domain, code, message }...] }`
+ * for partial/total failures inside an otherwise successful HTTP response,
+ * so without this check `--json` output silently looks like success.
+ *
+ * @param {object} response the subscribe response body
+ */
+function assertSubscribeSuccess (response) {
+  if (!response || typeof response !== 'object') {
+    return
+  }
+  const errorDetails = Array.isArray(response.errorDetails) ? response.errorDetails : []
+  const errorCodes = Array.isArray(response.error) ? response.error : []
+  if (errorDetails.length === 0 && errorCodes.length === 0) {
+    return
+  }
+  const formatted = errorDetails.length > 0
+    ? errorDetails.map(d => {
+        const where = d && d.sdkCode ? `${d.sdkCode}: ` : ''
+        const message = (d && d.message) || JSON.stringify(d)
+        return `  ${where}${message}`
+      }).join('\n')
+    : `  ${errorCodes.join(', ')}`
+  throw new Error(`Failed to add API service(s):\n${formatted}`)
 }
 
 class AddCommand extends ConsoleCommand {
@@ -162,6 +196,8 @@ class AddCommand extends ConsoleCommand {
         credentialType: LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL
       })
 
+      assertSubscribeSuccess(result)
+
       if (flags.json) {
         this.printJson(result)
       } else if (flags.yml) {
@@ -200,7 +236,7 @@ AddCommand.flags = {
     required: true
   }),
   'license-config': Flags.string({
-    description: 'Product profile(s) for a service, format: \'<sdkCode>=<profileNameOrId>[,<profileNameOrId>...]\'. Repeat for multiple services.',
+    description: 'Product profile(s) for a service, format: \'<sdkCode>=<profileNameOrIdOrProductId>[,<profileNameOrIdOrProductId>...]\'. Repeat for multiple services.',
     multiple: true
   }),
   json: Flags.boolean({
@@ -222,3 +258,4 @@ AddCommand.aliases = [
 module.exports = AddCommand
 module.exports.parseLicenseConfigFlags = parseLicenseConfigFlags
 module.exports.resolveLicenseConfigs = resolveLicenseConfigs
+module.exports.assertSubscribeSuccess = assertSubscribeSuccess

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -101,7 +101,8 @@ function pickServiceForCode (services, code) {
   if (matches.length === 0) {
     return undefined
   }
-  const entpWithProfiles = matches.find(s => s.type === 'entp' && s.properties && Array.isArray(s.properties.licenseConfigs) && s.properties.licenseConfigs.length > 0)
+  const hasLicenseConfigs = s => s.properties && Array.isArray(s.properties.licenseConfigs) && s.properties.licenseConfigs.length > 0
+  const entpWithProfiles = matches.find(s => s.type === 'entp' && hasLicenseConfigs(s))
   if (entpWithProfiles) {
     return entpWithProfiles
   }

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -21,7 +21,7 @@ const LibConsoleCLI = require('@adobe/aio-cli-lib-console')
  * Format: "<sdkCode>=<nameOrId>[,<nameOrId>...]"
  *
  * @param {string[]} values raw flag values
- * @returns {Object<string, string[]>} map of sdkCode to list of profile identifiers
+ * @returns {{[sdkCode: string]: string[]}} map of sdkCode to list of profile identifiers
  */
 function parseLicenseConfigFlags (values) {
   const result = {}
@@ -53,7 +53,7 @@ function parseLicenseConfigFlags (values) {
  * which is convenient for services like Frame.io that expose a single
  * profile per product.
  *
- * @param {Array<{id: string, name: string, productId: string}>} available
+ * @param {Array<{id: string, name: string, productId: string}>} available licenseConfigs reported for the service
  * @param {string[]} requested profile names, ids, or productIds
  * @param {string} sdkCode service code for error messages
  * @returns {Array} selected licenseConfig objects
@@ -101,7 +101,10 @@ function pickServiceForCode (services, code) {
   if (matches.length === 0) {
     return undefined
   }
-  const hasLicenseConfigs = s => s.properties && Array.isArray(s.properties.licenseConfigs) && s.properties.licenseConfigs.length > 0
+  const hasLicenseConfigs = s =>
+    s.properties &&
+    Array.isArray(s.properties.licenseConfigs) &&
+    s.properties.licenseConfigs.length > 0
   const entpWithProfiles = matches.find(s => s.type === 'entp' && hasLicenseConfigs(s))
   if (entpWithProfiles) {
     return entpWithProfiles
@@ -174,10 +177,10 @@ function assertSubscribeSuccess (response) {
   }
   const formatted = errorDetails.length > 0
     ? errorDetails.map(d => {
-        const where = d && d.sdkCode ? `${d.sdkCode}: ` : ''
-        const message = (d && d.message) || JSON.stringify(d)
-        return `  ${where}${message}`
-      }).join('\n')
+      const where = d && d.sdkCode ? `${d.sdkCode}: ` : ''
+      const message = (d && d.message) || JSON.stringify(d)
+      return `  ${where}${message}`
+    }).join('\n')
     : `  ${errorCodes.join(', ')}`
   throw new Error(`Failed to add API service(s):\n${formatted}`)
 }

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -45,6 +45,7 @@ const mockConsoleCLIInstance = {
   getProjects: jest.fn().mockResolvedValue([mockProject]),
   getWorkspaces: jest.fn().mockResolvedValue([mockWorkspace]),
   getEnabledServicesForOrg: jest.fn().mockResolvedValue(mockEnabledServices),
+  getServicePropertiesFromWorkspaceWithCredentialType: jest.fn().mockResolvedValue([]),
   subscribeToServicesWithCredentialType: jest.fn().mockResolvedValue(mockSubscribeResponse)
 }
 
@@ -56,7 +57,7 @@ jest.mock('@adobe/aio-cli-lib-console', () => ({
 }))
 
 const TheCommand = require('../../../../../src/commands/console/workspace/api/add')
-const { parseLicenseConfigFlags, resolveLicenseConfigs, assertSubscribeSuccess, pickServiceForCode } = TheCommand
+const { parseLicenseConfigFlags, resolveLicenseConfigs, assertSubscribeSuccess, pickServiceForCode, dedupeServicesByCode, mergeServiceProperties } = TheCommand
 
 describe('parseLicenseConfigFlags', () => {
   it('should parse a single sdkCode with one profile', () => {
@@ -172,6 +173,48 @@ describe('pickServiceForCode', () => {
   })
 })
 
+describe('dedupeServicesByCode', () => {
+  it('should return a single record per code, preferring entp+licenseConfigs', () => {
+    const services = [
+      { code: 'FrameioAPISDK', type: 'adobeid', properties: null },
+      { code: 'FrameioAPISDK', type: 'entp', properties: { licenseConfigs: [{ id: 'lc1' }] } },
+      { code: 'OtherSDK', type: 'entp' }
+    ]
+    const deduped = dedupeServicesByCode(services)
+    expect(deduped).toHaveLength(2)
+    expect(deduped.find(s => s.code === 'FrameioAPISDK')).toBe(services[1])
+    expect(deduped.find(s => s.code === 'OtherSDK')).toBe(services[2])
+  })
+
+  it('should be a no-op when no duplicates exist', () => {
+    const services = [{ code: 'A', type: 'entp' }, { code: 'B', type: 'entp' }]
+    expect(dedupeServicesByCode(services)).toEqual(services)
+  })
+})
+
+describe('mergeServiceProperties', () => {
+  it('should append new services when there is no overlap', () => {
+    const existing = [{ sdkCode: 'A' }]
+    const requested = [{ sdkCode: 'B' }]
+    expect(mergeServiceProperties(existing, requested)).toEqual([{ sdkCode: 'A' }, { sdkCode: 'B' }])
+  })
+
+  it('should let the requested entry win for overlapping sdkCodes', () => {
+    const existing = [{ sdkCode: 'A', licenseConfigs: [{ id: 'old' }] }]
+    const requested = [{ sdkCode: 'A', licenseConfigs: [{ id: 'new' }] }]
+    expect(mergeServiceProperties(existing, requested)).toEqual([{ sdkCode: 'A', licenseConfigs: [{ id: 'new' }] }])
+  })
+
+  it('should preserve existing services not in the requested list', () => {
+    const existing = [{ sdkCode: 'KeepMe' }, { sdkCode: 'Override' }]
+    const requested = [{ sdkCode: 'Override', updated: true }]
+    expect(mergeServiceProperties(existing, requested)).toEqual([
+      { sdkCode: 'KeepMe' },
+      { sdkCode: 'Override', updated: true }
+    ])
+  })
+})
+
 describe('assertSubscribeSuccess', () => {
   it('should not throw on a normal success response', () => {
     expect(() => assertSubscribeSuccess({ sdkList: ['AdobeAnalyticsSDK'] })).not.toThrow()
@@ -215,6 +258,7 @@ describe('console:workspace:api:add', () => {
     mockConsoleCLIInstance.getProjects.mockResolvedValue([mockProject])
     mockConsoleCLIInstance.getWorkspaces.mockResolvedValue([mockWorkspace])
     mockConsoleCLIInstance.getEnabledServicesForOrg.mockResolvedValue(mockEnabledServices)
+    mockConsoleCLIInstance.getServicePropertiesFromWorkspaceWithCredentialType.mockResolvedValue([])
     mockConsoleCLIInstance.subscribeToServicesWithCredentialType.mockResolvedValue(mockSubscribeResponse)
   })
 
@@ -458,6 +502,40 @@ describe('console:workspace:api:add', () => {
     expect(call.serviceProperties[0].licenseConfigs).toEqual([
       { id: '875473476', name: 'Default Frame.io Enterprise', productId: 'AA458DFE4F7020A0441A' }
     ])
+  })
+
+  it('should merge new services with services already on the credential', async () => {
+    // JIL's PUT-services replaces the credential's service list, so the
+    // command must submit the union of existing + new.
+    mockConsoleCLIInstance.getServicePropertiesFromWorkspaceWithCredentialType.mockResolvedValue([
+      { name: 'Existing SDK', sdkCode: 'ExistingSDK', roles: null, licenseConfigs: null }
+    ])
+    command.argv = [
+      '--service-code', 'AppBuilderDataServicesSDK',
+      '--projectName', 'myproject',
+      '--workspaceName', 'Stage',
+      '--orgId', '12345'
+    ]
+    await command.run()
+
+    const call = mockConsoleCLIInstance.subscribeToServicesWithCredentialType.mock.calls[0][0]
+    expect(call.serviceProperties.map(sp => sp.sdkCode)).toEqual(['ExistingSDK', 'AppBuilderDataServicesSDK'])
+  })
+
+  it('should not fail when fetching existing services errors out', async () => {
+    // A brand-new workspace has no credential yet; the lib's getServiceProperties
+    // call may reject. The command should fall back to "no existing services".
+    mockConsoleCLIInstance.getServicePropertiesFromWorkspaceWithCredentialType.mockRejectedValue(new Error('No credential'))
+    command.argv = [
+      '--service-code', 'AppBuilderDataServicesSDK',
+      '--projectName', 'myproject',
+      '--workspaceName', 'Stage',
+      '--orgId', '12345'
+    ]
+    await command.run()
+
+    const call = mockConsoleCLIInstance.subscribeToServicesWithCredentialType.mock.calls[0][0]
+    expect(call.serviceProperties.map(sp => sp.sdkCode)).toEqual(['AppBuilderDataServicesSDK'])
   })
 
   it('should surface JIL embedded errors as a CLI error', async () => {

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -383,6 +383,21 @@ describe('console:workspace:api:add', () => {
     await expect(command.run()).rejects.toThrow('Product profile(s) not found for service AdobeAnalyticsSDK: UnknownProfile')
   })
 
+  it('should error when --license-config references a code not in --service-code', async () => {
+    // Catches typos / casing mismatches that would otherwise silently
+    // drop the license-config entry while the unrelated --service-code
+    // succeeds.
+    command.argv = [
+      '--service-code', 'AppBuilderDataServicesSDK',
+      '--projectName', 'myproject',
+      '--workspaceName', 'Stage',
+      '--orgId', '12345',
+      '--license-config', 'FrameIOAPISDK=875473476'
+    ]
+    await expect(command.run()).rejects.toThrow(/--license-config given for service code\(s\) not in --service-code: FrameIOAPISDK[\s\S]*Requested service codes: AppBuilderDataServicesSDK/)
+    expect(mockConsoleCLIInstance.subscribeToServicesWithCredentialType).not.toHaveBeenCalled()
+  })
+
   it('should error on malformed --license-config value', async () => {
     command.argv = [
       '--service-code', 'AdobeAnalyticsSDK',

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -247,6 +247,24 @@ describe('assertSubscribeSuccess', () => {
     expect(() => assertSubscribeSuccess({ error: ['SomeSDK'] }))
       .toThrow(/Failed to add API service\(s\)[\s\S]*SomeSDK/)
   })
+
+  it('should format error details that lack a sdkCode', () => {
+    expect(() => assertSubscribeSuccess({
+      errorDetails: [{ domain: 'JIL', code: 500, message: 'kaboom' }]
+    })).toThrow(/Failed to add API service\(s\)[\s\S]*kaboom/)
+  })
+
+  it('should fall back to JSON.stringify when an error detail lacks a message', () => {
+    expect(() => assertSubscribeSuccess({
+      errorDetails: [{ sdkCode: 'WeirdSDK', code: 418 }]
+    })).toThrow(/Failed to add API service\(s\)[\s\S]*WeirdSDK:[\s\S]*"code":\s*418/)
+  })
+
+  it('should tolerate a null entry inside errorDetails', () => {
+    expect(() => assertSubscribeSuccess({
+      errorDetails: [null]
+    })).toThrow(/Failed to add API service\(s\)/)
+  })
 })
 
 describe('console:workspace:api:add', () => {

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -260,10 +260,10 @@ describe('assertSubscribeSuccess', () => {
     })).toThrow(/Failed to add API service\(s\)[\s\S]*WeirdSDK:[\s\S]*"code":\s*418/)
   })
 
-  it('should tolerate a null entry inside errorDetails', () => {
+  it('should render a null entry inside errorDetails as "(unknown error)"', () => {
     expect(() => assertSubscribeSuccess({
       errorDetails: [null]
-    })).toThrow(/Failed to add API service\(s\)/)
+    })).toThrow(/Failed to add API service\(s\)[\s\S]*\(unknown error\)/)
   })
 })
 

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -555,20 +555,21 @@ describe('console:workspace:api:add', () => {
     expect(call.serviceProperties.map(sp => sp.sdkCode)).toEqual(['ExistingSDK', 'AppBuilderDataServicesSDK'])
   })
 
-  it('should not fail when fetching existing services errors out', async () => {
-    // A brand-new workspace has no credential yet; the lib's getServiceProperties
-    // call may reject. The command should fall back to "no existing services".
-    mockConsoleCLIInstance.getServicePropertiesFromWorkspaceWithCredentialType.mockRejectedValue(new Error('No credential'))
+  it('should propagate failures to fetch existing services instead of overwriting silently', async () => {
+    // The lib returns [] (not throws) for a workspace without a credential
+    // yet, so a thrown error here is a real auth/network/server failure.
+    // Swallowing it and proceeding with [] would cause the credential's
+    // current services to be replaced by just the requested adds — the
+    // exact overwrite this merge is supposed to prevent.
+    mockConsoleCLIInstance.getServicePropertiesFromWorkspaceWithCredentialType.mockRejectedValue(new Error('network blew up'))
     command.argv = [
       '--service-code', 'AppBuilderDataServicesSDK',
       '--projectName', 'myproject',
       '--workspaceName', 'Stage',
       '--orgId', '12345'
     ]
-    await command.run()
-
-    const call = mockConsoleCLIInstance.subscribeToServicesWithCredentialType.mock.calls[0][0]
-    expect(call.serviceProperties.map(sp => sp.sdkCode)).toEqual(['AppBuilderDataServicesSDK'])
+    await expect(command.run()).rejects.toThrow('network blew up')
+    expect(mockConsoleCLIInstance.subscribeToServicesWithCredentialType).not.toHaveBeenCalled()
   })
 
   it('should surface JIL embedded errors as a CLI error', async () => {

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -56,7 +56,7 @@ jest.mock('@adobe/aio-cli-lib-console', () => ({
 }))
 
 const TheCommand = require('../../../../../src/commands/console/workspace/api/add')
-const { parseLicenseConfigFlags, resolveLicenseConfigs, assertSubscribeSuccess } = TheCommand
+const { parseLicenseConfigFlags, resolveLicenseConfigs, assertSubscribeSuccess, pickServiceForCode } = TheCommand
 
 describe('parseLicenseConfigFlags', () => {
   it('should parse a single sdkCode with one profile', () => {
@@ -135,6 +135,40 @@ describe('resolveLicenseConfigs', () => {
   it('should throw when a profile cannot be matched', () => {
     expect(() => resolveLicenseConfigs(available, ['bogus'], 'X'))
       .toThrow('Product profile(s) not found for service X: bogus')
+  })
+})
+
+describe('pickServiceForCode', () => {
+  it('should return undefined when no service matches the code', () => {
+    expect(pickServiceForCode([{ code: 'A', type: 'entp' }], 'B')).toBeUndefined()
+  })
+
+  it('should return the single match when there is no duplicate', () => {
+    const s = { code: 'A', type: 'entp', properties: { licenseConfigs: [{ id: 'lc1' }] } }
+    expect(pickServiceForCode([s], 'A')).toBe(s)
+  })
+
+  it('should prefer the entp record with populated licenseConfigs when a code appears twice', () => {
+    // Repro of the Frame.io case in getEnabledServicesForOrg
+    const adobeid = { code: 'FrameioAPISDK', type: 'adobeid', properties: null }
+    const entp = {
+      code: 'FrameioAPISDK',
+      type: 'entp',
+      properties: { licenseConfigs: [{ id: '875473476', productId: 'AA458DFE4F7020A0441A' }] }
+    }
+    expect(pickServiceForCode([adobeid, entp], 'FrameioAPISDK')).toBe(entp)
+  })
+
+  it('should fall back to an entp record without profiles before an adobeid record', () => {
+    const adobeid = { code: 'X', type: 'adobeid', properties: null }
+    const entp = { code: 'X', type: 'entp', properties: null }
+    expect(pickServiceForCode([adobeid, entp], 'X')).toBe(entp)
+  })
+
+  it('should fall back to the first match when no entp record exists', () => {
+    const a = { code: 'Y', type: 'adobeid' }
+    const b = { code: 'Y', type: 'adobeid' }
+    expect(pickServiceForCode([a, b], 'Y')).toBe(a)
   })
 })
 
@@ -390,6 +424,40 @@ describe('console:workspace:api:add', () => {
       '--orgId', '12345'
     ]
     await expect(command.run()).rejects.toThrow('SDK subscribe failed')
+  })
+
+  it('should prefer the entp duplicate service record when adobeid is listed first', async () => {
+    // Repro of the Frame.io shape in getEnabledServicesForOrg: same sdkCode
+    // appears once as adobeid (no licenseConfigs) and once as entp (with
+    // licenseConfigs). The pre-dedup code subscribed against the adobeid
+    // record and dropped --license-config silently.
+    mockConsoleCLIInstance.getEnabledServicesForOrg.mockResolvedValue([
+      { name: 'Frame.io API', code: 'FrameioAPISDK', type: 'adobeid', properties: null },
+      {
+        name: 'Frame.io API',
+        code: 'FrameioAPISDK',
+        type: 'entp',
+        properties: {
+          roles: [{ id: 1102, code: 'frame.s2s.all', name: null }],
+          licenseConfigs: [{ id: '875473476', name: 'Default Frame.io Enterprise', productId: 'AA458DFE4F7020A0441A' }]
+        }
+      }
+    ])
+    command.argv = [
+      '--service-code', 'FrameioAPISDK',
+      '--projectName', 'myproject',
+      '--workspaceName', 'Stage',
+      '--orgId', '12345',
+      '--license-config', 'FrameioAPISDK=875473476'
+    ]
+    await command.run()
+
+    const call = mockConsoleCLIInstance.subscribeToServicesWithCredentialType.mock.calls[0][0]
+    expect(call.serviceProperties).toHaveLength(1)
+    expect(call.serviceProperties[0].sdkCode).toBe('FrameioAPISDK')
+    expect(call.serviceProperties[0].licenseConfigs).toEqual([
+      { id: '875473476', name: 'Default Frame.io Enterprise', productId: 'AA458DFE4F7020A0441A' }
+    ])
   })
 
   it('should surface JIL embedded errors as a CLI error', async () => {

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -56,7 +56,7 @@ jest.mock('@adobe/aio-cli-lib-console', () => ({
 }))
 
 const TheCommand = require('../../../../../src/commands/console/workspace/api/add')
-const { parseLicenseConfigFlags, resolveLicenseConfigs } = TheCommand
+const { parseLicenseConfigFlags, resolveLicenseConfigs, assertSubscribeSuccess } = TheCommand
 
 describe('parseLicenseConfigFlags', () => {
   it('should parse a single sdkCode with one profile', () => {
@@ -121,6 +121,13 @@ describe('resolveLicenseConfigs', () => {
     expect(resolveLicenseConfigs(available, ['ProfileB'], 'X')).toEqual([available[1]])
   })
 
+  it('should match a profile by productId', () => {
+    const single = [
+      { id: '875473476', name: 'Default Frame.io Enterprise', productId: 'AA458DFE4F7020A0441A' }
+    ]
+    expect(resolveLicenseConfigs(single, ['AA458DFE4F7020A0441A'], 'FrameioAPISDK')).toEqual([single[0]])
+  })
+
   it('should match multiple profiles mixing id and name', () => {
     expect(resolveLicenseConfigs(available, ['lc1', 'ProfileB'], 'X')).toEqual(available)
   })
@@ -128,6 +135,40 @@ describe('resolveLicenseConfigs', () => {
   it('should throw when a profile cannot be matched', () => {
     expect(() => resolveLicenseConfigs(available, ['bogus'], 'X'))
       .toThrow('Product profile(s) not found for service X: bogus')
+  })
+})
+
+describe('assertSubscribeSuccess', () => {
+  it('should not throw on a normal success response', () => {
+    expect(() => assertSubscribeSuccess({ sdkList: ['AdobeAnalyticsSDK'] })).not.toThrow()
+  })
+
+  it('should not throw on null/undefined', () => {
+    expect(() => assertSubscribeSuccess(null)).not.toThrow()
+    expect(() => assertSubscribeSuccess(undefined)).not.toThrow()
+  })
+
+  it('should not throw on empty error arrays', () => {
+    expect(() => assertSubscribeSuccess({ sdkList: [], error: [], errorDetails: [] })).not.toThrow()
+  })
+
+  it('should surface the JIL "requires selection of a product" error', () => {
+    const jilErrorResponse = {
+      error: ['FrameioAPISDK'],
+      errorDetails: [{
+        sdkCode: 'FrameioAPISDK',
+        domain: 'JIL',
+        code: 400,
+        message: 'Service FrameioAPISDK requires selection of a product'
+      }]
+    }
+    expect(() => assertSubscribeSuccess(jilErrorResponse))
+      .toThrow(/Failed to add API service\(s\)[\s\S]*FrameioAPISDK: Service FrameioAPISDK requires selection of a product/)
+  })
+
+  it('should fall back to error[] when errorDetails is missing', () => {
+    expect(() => assertSubscribeSuccess({ error: ['SomeSDK'] }))
+      .toThrow(/Failed to add API service\(s\)[\s\S]*SomeSDK/)
   })
 })
 
@@ -349,6 +390,25 @@ describe('console:workspace:api:add', () => {
       '--orgId', '12345'
     ]
     await expect(command.run()).rejects.toThrow('SDK subscribe failed')
+  })
+
+  it('should surface JIL embedded errors as a CLI error', async () => {
+    mockConsoleCLIInstance.subscribeToServicesWithCredentialType.mockResolvedValue({
+      error: ['AppBuilderDataServicesSDK'],
+      errorDetails: [{
+        sdkCode: 'AppBuilderDataServicesSDK',
+        domain: 'JIL',
+        code: 400,
+        message: 'Service AppBuilderDataServicesSDK requires selection of a product'
+      }]
+    })
+    command.argv = [
+      '--service-code', 'AppBuilderDataServicesSDK',
+      '--projectName', 'myproject',
+      '--workspaceName', 'Stage',
+      '--orgId', '12345'
+    ]
+    await expect(command.run()).rejects.toThrow('requires selection of a product')
   })
 
   it('should output JSON when --json is used', async () => {


### PR DESCRIPTION
## Summary

Three related fixes to `aio console workspace api add`, all surfaced by a Frame.io API subscription failure in a customer-facing org. Each is independently correct and ships together to leave the command in a consistent state.

### 1. Surface JIL embedded errors as CLI errors
JIL's subscribe endpoint returns 200 with `{ error: [...], errorDetails: [...] }` embedded for partial/total failures. The CLI was passing that through `--json` as if it succeeded, so scripts checking exit code silently passed while the subscription never landed. New `assertSubscribeSuccess` runs after the subscribe call and throws a CLI error if `error[]` or `errorDetails[]` is non-empty.

### 2. Dedupe duplicate service records by sdkCode
Some orgs return the same `sdkCode` twice in `getEnabledServicesForOrg` — once as `type: 'adobeid'` (browser/SPA flow, no `licenseConfigs`) and once as `type: 'entp'` (with the product profile metadata required for OAuth Server-to-Server). The previous `Array.find` by code returned whichever the API listed first; in the repro org that was the adobeid record, so `--license-config` was silently dropped and JIL rejected the subscription with "requires selection of a product".

New `pickServiceForCode` prefers the entp record with populated `licenseConfigs` when a code appears more than once, matching how the existing interactive prompt filters services. `dedupeServicesByCode` applies this up front so subsequent code can just `.find()`.

Also extended `resolveLicenseConfigs` to match by `productId` (in addition to `id` and `name`), since users looking at `aio console api list` reasonably try the `productId` they see under `properties.licenseConfigs[].productId`.

### 3. Make `api add` additive instead of overwriting (closes #258)
JIL's PUT-services endpoint is set-based — it replaces the credential's service list rather than appending. Any second call to `aio console workspace api add` silently wiped services from the first call, breaking deployed apps that depended on the removed scopes with no deploy-time signal.

Fetch the credential's current `serviceProperties` via `getServicePropertiesFromWorkspaceWithCredentialType`, merge with the requested adds (requested entry wins on sdkCode overlap so users can still update licenseConfigs), and submit the union. Failure to fetch (e.g. brand-new workspace with no credential yet) is caught and treated as "no existing services" so the first-time path still works.

## End-to-end verification

Against a fresh test project in the repro org (Forward Deployed Engineering - Firefly Services):

- `api add --service-code FrameioAPISDK --license-config FrameioAPISDK=875473476` against Stage → success, credential carries `frame.s2s.all` scope
- Same against Production → success
- Sequential single-service adds of `AdobeIOManagementAPISDK`, then `FrameioAPISDK`, then `AppBuilderDataServicesSDK` → credential ends up subscribed to all three with their scopes intact (previously the second and third calls would have dropped the prior services)
- Confirmed working by the original reporter against their own org

## Test plan

- [x] Unit + integration tests: 49/49 passing, 100% line coverage on `add.js`
- [x] Live-fire test against the Frame.io-enabled org for both fresh workspaces and incremental adds
- [x] Confirmed by the reporter against their production setup

## Closes

- Closes #258
- ACNA-4617