### PR TITLE
feat: fix the 451 CoreConsole error into a better user flow to accept developer terms

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@adobe/aio-lib-env": "^3",
     "@adobe/aio-lib-ims": "^7",
     "@oclif/core": "^4.0.0",
+    "hyperlinker": "^1.0.0",
     "js-yaml": "^4.1.0",
     "open": "^10.2.0"
   },

--- a/src/commands/console/api/list.js
+++ b/src/commands/console/api/list.js
@@ -27,6 +27,7 @@ class ListCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const enabledServices = await this.consoleCLI.getEnabledServicesForOrg(orgId)
       aioConsoleLogger.debug(`Enabled services: ${JSON.stringify(enabledServices.map(s => s.code))}`)
 

--- a/src/commands/console/index.js
+++ b/src/commands/console/index.js
@@ -113,7 +113,8 @@ class ConsoleCommand extends Command {
       this.error('Developer Terms of Service have not been accepted for this organization. Please re-run this command without `--json`/`--yml`, or run `aio app init` to accept the terms first.')
     }
     const terms = await consoleCLI.getDevTermsForOrg()
-    const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${terms.text}\n\nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker(DEV_TERMS_URL, DEV_TERMS_URL)} to view the terms. Do you accept the terms? (y/n):`)
+    const termsText = terms.text ? terms.text.trimEnd() : ''
+    const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${termsText}\n\nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker(DEV_TERMS_URL, DEV_TERMS_URL)} to view the terms. Do you accept the terms? (y/n):`)
     if (!confirmDevTerms) {
       this.error('The Developer Terms of Service were declined')
     }

--- a/src/commands/console/index.js
+++ b/src/commands/console/index.js
@@ -113,7 +113,7 @@ class ConsoleCommand extends Command {
       this.error('Developer Terms of Service have not been accepted for this organization. Please re-run this command without `--json`/`--yml`, or run `aio app init` to accept the terms first.')
     }
     const terms = await consoleCLI.getDevTermsForOrg()
-    const termsText = terms.text ? terms.text.trimEnd() : ''
+    const termsText = terms.text ? terms.text.trim() : ''
     const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${termsText}\n\nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker(DEV_TERMS_URL, DEV_TERMS_URL)} to view the terms. Do you accept the terms? (y/n):`)
     if (!confirmDevTerms) {
       this.error('The Developer Terms of Service were declined')

--- a/src/commands/console/index.js
+++ b/src/commands/console/index.js
@@ -113,8 +113,7 @@ class ConsoleCommand extends Command {
       this.error('Developer Terms of Service have not been accepted for this organization. Please re-run this command without `--json`/`--yml`, or run `aio app init` to accept the terms first.')
     }
     const terms = await consoleCLI.getDevTermsForOrg()
-    const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${terms.text}
-    \nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker(DEV_TERMS_URL, DEV_TERMS_URL)} to view the terms. Do you accept the terms? (y/n):`)
+    const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${terms.text}\n\nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker(DEV_TERMS_URL, DEV_TERMS_URL)} to view the terms. Do you accept the terms? (y/n):`)
     if (!confirmDevTerms) {
       this.error('The Developer Terms of Service were declined')
     }

--- a/src/commands/console/index.js
+++ b/src/commands/console/index.js
@@ -18,7 +18,10 @@ const LibConsoleCLI = require('@adobe/aio-cli-lib-console')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
 const { getCliEnv } = require('@adobe/aio-lib-env')
 const yaml = require('js-yaml')
+const hyperlinker = require('hyperlinker')
 const { CONFIG_KEYS, API_KEYS } = require('../../config')
+
+const DEV_TERMS_URL = 'https://www.adobe.com/go/developer-terms'
 
 class ConsoleCommand extends Command {
   async run () {
@@ -87,6 +90,39 @@ class ConsoleCommand extends Command {
 
   cleanOutput () {
     LibConsoleCLI.cleanStdOut()
+  }
+
+  /**
+   * Ensure the Developer Terms of Service have been accepted for the given org.
+   * Mirrors the flow in @adobe/aio-cli-plugin-app's `app init` command so that
+   * `console` subcommands surface a CLI-native prompt instead of leaking a raw
+   * 451 "use POST /console/services/ims/organizations/:orgId/terms" message
+   * from the underlying SDK.
+   *
+   * @param {object} consoleCLI initialised @adobe/aio-cli-lib-console instance (this.consoleCLI)
+   * @param {string} orgId organization id to check
+   * @param {boolean} [skipPrompts] when true, fail fast instead of prompting (default false)
+   * @returns {Promise<void>}
+   */
+  async ensureDevTermAccepted (consoleCLI, orgId, skipPrompts = false) {
+    const isTermAccepted = await consoleCLI.checkDevTermsForOrg(orgId)
+    if (isTermAccepted) {
+      return
+    }
+    if (skipPrompts) {
+      this.error('Developer Terms of Service have not been accepted for this organization. Please re-run this command without `--json`/`--yml`, or run `aio app init` to accept the terms first.')
+    }
+    const terms = await consoleCLI.getDevTermsForOrg()
+    const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${terms.text}
+    \nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker(DEV_TERMS_URL, DEV_TERMS_URL)} to view the terms. Do you accept the terms? (y/n):`)
+    if (!confirmDevTerms) {
+      this.error('The Developer Terms of Service were declined')
+    }
+    const accepted = await consoleCLI.acceptDevTermsForOrg(orgId)
+    if (!accepted) {
+      this.error('The Developer Terms of Service could not be accepted')
+    }
+    this.log(`The Developer Terms of Service were successfully accepted for org ${orgId}`)
   }
 
   /**

--- a/src/commands/console/project/create.js
+++ b/src/commands/console/project/create.js
@@ -54,6 +54,7 @@ class CreateCommand extends ConsoleCommand {
 
     await this.initSdk()
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       // check name is not already in use
       const projects = await this.consoleCLI.getProjects(orgId)
       if (projects.find(project => project.name === projectDetails.name)) {

--- a/src/commands/console/project/list.js
+++ b/src/commands/console/project/list.js
@@ -27,6 +27,7 @@ class ListCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const projects = await this.getConsoleOrgProjects(orgId)
 
       if (flags.json) {

--- a/src/commands/console/project/select.js
+++ b/src/commands/console/project/select.js
@@ -29,6 +29,7 @@ class SelectCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId)
       const project = await this.selectProjectInteractive(orgId, args.projectIdOrName)
 
       this.setConfig(CONFIG_KEYS.PROJECT, project)

--- a/src/commands/console/publickey/delete.js
+++ b/src/commands/console/publickey/delete.js
@@ -41,6 +41,7 @@ class DeleteCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId)
       const consoleConfig = await this.consoleCLI.getWorkspaceConfig(orgId, projectId, workspaceId)
 
       const project = consoleConfig.project

--- a/src/commands/console/publickey/list.js
+++ b/src/commands/console/publickey/list.js
@@ -43,6 +43,7 @@ class ListCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const consoleConfig = await this.consoleCLI.getWorkspaceConfig(orgId, projectId, workspaceId)
 
       const project = consoleConfig.project

--- a/src/commands/console/publickey/upload.js
+++ b/src/commands/console/publickey/upload.js
@@ -53,6 +53,7 @@ class UploadAndBindCommand extends ConsoleCommand {
 
     await this.initSdk()
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const consoleConfig = await this.consoleCLI.getWorkspaceConfig(orgId, projectId, workspaceId)
 
       const project = consoleConfig.project

--- a/src/commands/console/workspace/api/add.js
+++ b/src/commands/console/workspace/api/add.js
@@ -199,6 +199,7 @@ class AddCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const projects = await this.consoleCLI.getProjects(orgId)
       const project = projects.find(p => p.name === flags.projectName)
       if (!project) {

--- a/src/commands/console/workspace/api/list.js
+++ b/src/commands/console/workspace/api/list.js
@@ -28,6 +28,7 @@ class ListCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const projects = await this.consoleCLI.getProjects(orgId)
       const project = projects.find(p => p.name === flags.projectName)
       if (!project) {

--- a/src/commands/console/workspace/create.js
+++ b/src/commands/console/workspace/create.js
@@ -46,6 +46,7 @@ class CreateCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       // resolve project by name to project id
       const projects = await this.consoleCLI.getProjects(orgId)
       const project = projects.find(p => p.name === flags.projectName)

--- a/src/commands/console/workspace/download.js
+++ b/src/commands/console/workspace/download.js
@@ -45,6 +45,7 @@ class DownloadCommand extends ConsoleCommand {
 
     await this.initSdk()
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId)
       const consoleConfig = await this.consoleCLI.getWorkspaceConfig(orgId, projectId, workspaceId)
 
       let fileName = 'console.json'

--- a/src/commands/console/workspace/list.js
+++ b/src/commands/console/workspace/list.js
@@ -37,6 +37,7 @@ class ListCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId, flags.json || flags.yml)
       const workspaces = await this.getConsoleProjectWorkspaces(orgId, projectId)
 
       if (flags.json) {

--- a/src/commands/console/workspace/select.js
+++ b/src/commands/console/workspace/select.js
@@ -36,6 +36,7 @@ class SelectCommand extends ConsoleCommand {
     await this.initSdk()
 
     try {
+      await this.ensureDevTermAccepted(this.consoleCLI, orgId)
       const workspace = await this.selectWorkspaceInteractive(orgId, projectId, args.workspaceIdOrName)
 
       const obj = {

--- a/test/commands/console/api/list.test.js
+++ b/test/commands/console/api/list.test.js
@@ -37,7 +37,11 @@ const mockEnabledServices = [
 ]
 
 const mockConsoleCLIInstance = {
-  getEnabledServicesForOrg: jest.fn().mockResolvedValue(mockEnabledServices)
+  getEnabledServicesForOrg: jest.fn().mockResolvedValue(mockEnabledServices),
+  checkDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  getDevTermsForOrg: jest.fn().mockResolvedValue({ text: 'terms' }),
+  acceptDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  prompt: { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 
 jest.mock('@adobe/aio-cli-lib-console', () => {

--- a/test/commands/console/index.test.js
+++ b/test/commands/console/index.test.js
@@ -293,5 +293,13 @@ describe('ConsoleCommand', () => {
       expect(promptArg).toContain('https://www.adobe.com/go/developer-terms')
       expect(promptArg).toContain('Developer Terms text')
     })
+
+    test('handles missing terms text in the prompt', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      mockConsoleCLI.getDevTermsForOrg.mockResolvedValue({})
+      await command.ensureDevTermAccepted(mockConsoleCLI, 'org-1')
+      const promptArg = mockConsoleCLI.prompt.promptConfirm.mock.calls[0][0]
+      expect(promptArg).toContain('You have not accepted the Developer Terms of Service.')
+    })
   })
 })

--- a/test/commands/console/index.test.js
+++ b/test/commands/console/index.test.js
@@ -227,4 +227,71 @@ describe('ConsoleCommand', () => {
       expect(config.delete).toHaveBeenCalledWith(CONFIG_KEYS.CONSOLE)
     })
   })
+
+  describe('ensureDevTermAccepted', () => {
+    let mockConsoleCLI
+
+    beforeEach(() => {
+      mockConsoleCLI = {
+        checkDevTermsForOrg: jest.fn().mockResolvedValue(true),
+        getDevTermsForOrg: jest.fn().mockResolvedValue({ text: 'Developer Terms text' }),
+        acceptDevTermsForOrg: jest.fn().mockResolvedValue(true),
+        prompt: { promptConfirm: jest.fn().mockResolvedValue(true) }
+      }
+      command.error = jest.fn((msg) => { throw new Error(msg) })
+      command.log = jest.fn()
+    })
+
+    test('no-op when terms already accepted', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(true)
+      await command.ensureDevTermAccepted(mockConsoleCLI, 'org-1')
+      expect(mockConsoleCLI.checkDevTermsForOrg).toHaveBeenCalledWith('org-1')
+      expect(mockConsoleCLI.getDevTermsForOrg).not.toHaveBeenCalled()
+      expect(mockConsoleCLI.prompt.promptConfirm).not.toHaveBeenCalled()
+      expect(mockConsoleCLI.acceptDevTermsForOrg).not.toHaveBeenCalled()
+      expect(command.log).not.toHaveBeenCalled()
+    })
+
+    test('errors fast when terms not accepted and skipPrompts=true', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      await expect(command.ensureDevTermAccepted(mockConsoleCLI, 'org-1', true))
+        .rejects.toThrow(/Developer Terms of Service have not been accepted/)
+      expect(mockConsoleCLI.getDevTermsForOrg).not.toHaveBeenCalled()
+      expect(mockConsoleCLI.prompt.promptConfirm).not.toHaveBeenCalled()
+    })
+
+    test('errors when user declines the terms', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      mockConsoleCLI.prompt.promptConfirm.mockResolvedValue(false)
+      await expect(command.ensureDevTermAccepted(mockConsoleCLI, 'org-1'))
+        .rejects.toThrow('The Developer Terms of Service were declined')
+      expect(mockConsoleCLI.getDevTermsForOrg).toHaveBeenCalled()
+      expect(mockConsoleCLI.acceptDevTermsForOrg).not.toHaveBeenCalled()
+    })
+
+    test('accepts terms programmatically when user confirms', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      mockConsoleCLI.prompt.promptConfirm.mockResolvedValue(true)
+      mockConsoleCLI.acceptDevTermsForOrg.mockResolvedValue(true)
+      await command.ensureDevTermAccepted(mockConsoleCLI, 'org-1')
+      expect(mockConsoleCLI.acceptDevTermsForOrg).toHaveBeenCalledWith('org-1')
+      expect(command.log).toHaveBeenCalledWith(expect.stringContaining('successfully accepted'))
+    })
+
+    test('errors when accept call returns false', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      mockConsoleCLI.prompt.promptConfirm.mockResolvedValue(true)
+      mockConsoleCLI.acceptDevTermsForOrg.mockResolvedValue(false)
+      await expect(command.ensureDevTermAccepted(mockConsoleCLI, 'org-1'))
+        .rejects.toThrow('The Developer Terms of Service could not be accepted')
+    })
+
+    test('includes the terms URL in the prompt', async () => {
+      mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      await command.ensureDevTermAccepted(mockConsoleCLI, 'org-1')
+      const promptArg = mockConsoleCLI.prompt.promptConfirm.mock.calls[0][0]
+      expect(promptArg).toContain('https://www.adobe.com/go/developer-terms')
+      expect(promptArg).toContain('Developer Terms text')
+    })
+  })
 })

--- a/test/commands/console/index.test.js
+++ b/test/commands/console/index.test.js
@@ -288,10 +288,12 @@ describe('ConsoleCommand', () => {
 
     test('includes the terms URL in the prompt', async () => {
       mockConsoleCLI.checkDevTermsForOrg.mockResolvedValue(false)
+      mockConsoleCLI.getDevTermsForOrg.mockResolvedValue({ text: '\n  Developer Terms text  \n' })
       await command.ensureDevTermAccepted(mockConsoleCLI, 'org-1')
       const promptArg = mockConsoleCLI.prompt.promptConfirm.mock.calls[0][0]
       expect(promptArg).toContain('https://www.adobe.com/go/developer-terms')
       expect(promptArg).toContain('Developer Terms text')
+      expect(promptArg).toMatch(/^Developer Terms text\n\nYou have not accepted/)
     })
 
     test('handles missing terms text in the prompt', async () => {

--- a/test/commands/console/open.test.js
+++ b/test/commands/console/open.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 const TestCommand = require('../../../src/commands/console/open')
 const config = require('@adobe/aio-lib-core-config')
-const { STAGE_ENV } = require('@adobe/aio-lib-env')
+const { PROD_ENV, STAGE_ENV } = require('@adobe/aio-lib-env')
 
 const mockOpen = jest.fn()
 jest.unstable_mockModule('open', () => ({
@@ -25,6 +25,7 @@ beforeAll(() => {
   ORIGINAL_AIO_CLI_ENV = process.env.AIO_CLI_ENV
 })
 beforeEach(() => {
+  process.env.AIO_CLI_ENV = PROD_ENV
   config.get.mockReset()
   mockOpen.mockReset()
   command = new TestCommand([])

--- a/test/commands/console/project/create.test.js
+++ b/test/commands/console/project/create.test.js
@@ -26,7 +26,11 @@ const mockProject = {
 
 const mockConsoleCLIInstance = {
   getProjects: jest.fn().mockResolvedValue([]),
-  createProject: jest.fn().mockResolvedValue(mockProject)
+  createProject: jest.fn().mockResolvedValue(mockProject),
+  checkDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  getDevTermsForOrg: jest.fn().mockResolvedValue({ text: 'terms' }),
+  acceptDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  prompt: { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 
 jest.mock('@adobe/aio-cli-lib-console', () => ({
@@ -46,6 +50,7 @@ describe('console:project:create', () => {
     mockConsoleCLIInstance.createProject = jest.fn().mockResolvedValue(mockProject)
     mockConsoleCLIInstance.getProjects.mockReset()
     mockConsoleCLIInstance.getProjects = jest.fn().mockResolvedValue([])
+    mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
   })
 
   afterEach(() => {

--- a/test/commands/console/project/list.test.js
+++ b/test/commands/console/project/list.test.js
@@ -44,6 +44,10 @@ const mockConsoleCLIInstance = {}
  */
 function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getProjects = jest.fn().mockResolvedValue(projects)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
@@ -115,6 +119,15 @@ describe('console:project:list', () => {
     await expect(command.run()).resolves.not.toThrow()
     expect(JSON.parse(stdout.output)).toMatchFixtureJson('project/list.json')
     expect(mockConsoleCLIInstance.getProjects).toHaveBeenCalledWith('1001')
+  })
+
+  test('should not prompt for developer terms when returning projects as json', async () => {
+    mockConsoleCLIInstance.checkDevTermsForOrg.mockResolvedValue(false)
+    command.argv = ['--orgId', '1001', '--json']
+
+    await expect(command.run()).rejects.toThrow('Developer Terms of Service have not been accepted')
+    expect(mockConsoleCLIInstance.prompt.promptConfirm).not.toHaveBeenCalled()
+    expect(mockConsoleCLIInstance.getProjects).not.toHaveBeenCalled()
   })
 
   test('should return list of projects yaml', async () => {

--- a/test/commands/console/project/select.test.js
+++ b/test/commands/console/project/select.test.js
@@ -42,6 +42,10 @@ const mockConsoleCLIInstance = {}
 function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getProjects = jest.fn().mockResolvedValue(projects)
   mockConsoleCLIInstance.promptForSelectProject = jest.fn().mockResolvedValue(selectedProject)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 
 jest.mock('@adobe/aio-cli-lib-console', () => ({

--- a/test/commands/console/publickey/delete.test.js
+++ b/test/commands/console/publickey/delete.test.js
@@ -49,6 +49,10 @@ function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getWorkspaceConfig = jest.fn().mockResolvedValue(consoleConfig)
   mockConsoleCLIInstance.getBindingsForWorkspace = jest.fn().mockResolvedValue([binding1, binding2])
   mockConsoleCLIInstance.deleteBindingFromWorkspace = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),

--- a/test/commands/console/publickey/list.test.js
+++ b/test/commands/console/publickey/list.test.js
@@ -50,6 +50,10 @@ const mockConsoleCLIInstance = {}
 function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getWorkspaceConfig = jest.fn().mockResolvedValue(consoleConfig)
   mockConsoleCLIInstance.getBindingsForWorkspace = jest.fn().mockResolvedValue(bindings)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),

--- a/test/commands/console/publickey/upload.test.js
+++ b/test/commands/console/publickey/upload.test.js
@@ -51,6 +51,10 @@ function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getBindingsForWorkspace = jest.fn().mockResolvedValue([binding1])
   mockConsoleCLIInstance.uploadAndBindCertificateToWorkspace = jest.fn().mockResolvedValue(binding2)
   mockConsoleCLIInstance.getCertificateFingerprint = jest.fn().mockResolvedValue({ certificateFingerprint: 'cf2' })
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),

--- a/test/commands/console/workspace/api/add.test.js
+++ b/test/commands/console/workspace/api/add.test.js
@@ -46,7 +46,11 @@ const mockConsoleCLIInstance = {
   getWorkspaces: jest.fn().mockResolvedValue([mockWorkspace]),
   getEnabledServicesForOrg: jest.fn().mockResolvedValue(mockEnabledServices),
   getServicePropertiesFromWorkspaceWithCredentialType: jest.fn().mockResolvedValue([]),
-  subscribeToServicesWithCredentialType: jest.fn().mockResolvedValue(mockSubscribeResponse)
+  subscribeToServicesWithCredentialType: jest.fn().mockResolvedValue(mockSubscribeResponse),
+  checkDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  getDevTermsForOrg: jest.fn().mockResolvedValue({ text: 'terms' }),
+  acceptDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  prompt: { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 
 jest.mock('@adobe/aio-cli-lib-console', () => ({

--- a/test/commands/console/workspace/api/list.test.js
+++ b/test/commands/console/workspace/api/list.test.js
@@ -40,7 +40,11 @@ const mockConsoleCLIInstance = {
   getProjects: jest.fn().mockResolvedValue([mockProject]),
   getWorkspaces: jest.fn().mockResolvedValue([mockWorkspace]),
   getEnabledServicesForOrg: jest.fn().mockResolvedValue(mockEnabledServices),
-  getServicePropertiesFromWorkspaceWithCredentialType: jest.fn().mockResolvedValue(mockSubscribedServiceProperties)
+  getServicePropertiesFromWorkspaceWithCredentialType: jest.fn().mockResolvedValue(mockSubscribedServiceProperties),
+  checkDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  getDevTermsForOrg: jest.fn().mockResolvedValue({ text: 'terms' }),
+  acceptDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  prompt: { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 
 jest.mock('@adobe/aio-cli-lib-console', () => {

--- a/test/commands/console/workspace/create.test.js
+++ b/test/commands/console/workspace/create.test.js
@@ -25,7 +25,11 @@ const mockWorkspace = {
 const mockConsoleCLIInstance = {
   getProjects: jest.fn().mockResolvedValue([mockProject]),
   getWorkspaces: jest.fn().mockResolvedValue([]),
-  createWorkspace: jest.fn().mockResolvedValue(mockWorkspace)
+  createWorkspace: jest.fn().mockResolvedValue(mockWorkspace),
+  checkDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  getDevTermsForOrg: jest.fn().mockResolvedValue({ text: 'terms' }),
+  acceptDevTermsForOrg: jest.fn().mockResolvedValue(true),
+  prompt: { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 
 jest.mock('@adobe/aio-cli-lib-console', () => ({
@@ -46,6 +50,7 @@ describe('console:workspace:create', () => {
     mockConsoleCLIInstance.getWorkspaces.mockResolvedValue([])
     mockConsoleCLIInstance.getProjects.mockReset()
     mockConsoleCLIInstance.getProjects.mockResolvedValue([mockProject])
+    mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
   })
 
   afterEach(() => {

--- a/test/commands/console/workspace/download.test.js
+++ b/test/commands/console/workspace/download.test.js
@@ -27,6 +27,10 @@ const mockConsoleCLIInstance = {}
 function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getWorkspaceConfig = jest.fn()
   mockConsoleCLIInstance.getWorkspaceConfig.mockResolvedValue(fakeConfig)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),

--- a/test/commands/console/workspace/list.test.js
+++ b/test/commands/console/workspace/list.test.js
@@ -24,6 +24,10 @@ const mockConsoleCLIInstance = {}
 /** @private */
 function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getWorkspaces = jest.fn().mockResolvedValue(workspaces)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),

--- a/test/commands/console/workspace/select.test.js
+++ b/test/commands/console/workspace/select.test.js
@@ -25,6 +25,10 @@ const mockConsoleCLIInstance = {}
 function setDefaultMockConsoleCLI () {
   mockConsoleCLIInstance.getWorkspaces = jest.fn().mockResolvedValue(workspaces)
   mockConsoleCLIInstance.promptForSelectWorkspace = jest.fn().mockResolvedValue(selectedWorkspace)
+  mockConsoleCLIInstance.checkDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.getDevTermsForOrg = jest.fn().mockResolvedValue({ text: 'terms' })
+  mockConsoleCLIInstance.acceptDevTermsForOrg = jest.fn().mockResolvedValue(true)
+  mockConsoleCLIInstance.prompt = { promptConfirm: jest.fn().mockResolvedValue(true) }
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
   init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR handles the Developer Terms of Service acceptance flow before Console commands call terms-gated Developer Console APIs.
When the selected org has not accepted the current Developer Terms, interactive Console commands now show a CLI-native prompt and can accept the terms through the existing Console SDK methods. 
Structured-output commands using `--json` or `--yml` fail fast with an actionable error instead of prompting, so scripts and CI consumers do not receive invalid JSON/YAML output.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aio-cli-plugin-console/issues/203

## Motivation and Context

Users who had not accepted Developer Terms could see a raw 451 Console API error telling them to call the terms API manually. Hence the Console plugin needed to surface a helpful, user-facing flow for this specific terms-acceptance condition.
This mirrors the existing `aio-cli-plugin-app` approach for interactive usage while preserving machine-readable output for `--json` and `--yml` commands.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

npm test ( 100% unit test coverage maintained)

### Manual testing steps
`aio plugins link .`

## Screenshots (if appropriate):
Deeptys-MacBook-Pro-2:Downloads dthampy$ aio console project ls
<img width="1913" height="101" alt="Screenshot 2026-06-10 at 6 17 35 PM" src="https://github.com/user-attachments/assets/bf518ad3-0f8f-4eac-b739-c20d2287b091" />
<img width="1905" height="116" alt="Screenshot 2026-06-10 at 6 18 30 PM" src="https://github.com/user-attachments/assets/875cd8eb-680c-4742-9579-2bff8a531670" />



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
